### PR TITLE
Remove TODO links from the output

### DIFF
--- a/src/bin/generate.ts
+++ b/src/bin/generate.ts
@@ -11,7 +11,7 @@ import stringify from 'remark-stringify';
 import unified from 'unified';
 import { promisify } from 'util';
 
-import { runCodeBlocks, zoeySays } from '../lib';
+import { runCodeBlocks, todoLinks, zoeySays } from '../lib';
 
 const glob = promisify(_glob);
 const readFile = promisify(_readFile);
@@ -36,6 +36,7 @@ async function main() {
   const processor = unified()
     .use(markdown)
     .use(runCodeBlocks, { cwd: codeDir })
+    .use(todoLinks)
     .use(zoeySays)
     .use(stringify, { fences: true });
 

--- a/src/chapters/02-building-pages.md
+++ b/src/chapters/02-building-pages.md
@@ -2,7 +2,7 @@ With our [first page](../01-orientation) down, let's add another one!
 
 This time, we would like the page to be served on the `/about` URL. In order to do this, we will need to tell Ember about our plan to add a page at that location. Otherwise, Ember will think we have visited an invalid URL!
 
-The place to manage what pages are available is the *[router](TODO: link to router)*. Go ahead and open `app/router.js` and make the following change:
+The place to manage what pages are available is the *[router][TODO: link to router]*. Go ahead and open `app/router.js` and make the following change:
 
 ```run:file:patch lang=js cwd=super-rentals filename=app/router.js
 @@ -9,2 +9,3 @@
@@ -11,7 +11,7 @@ The place to manage what pages are available is the *[router](TODO: link to rout
  });
 ```
 
-This adds a *[route](TODO: link to route)* named "about", which is served at the `/about` URL by default.
+This adds a *[route][TODO: link to route]* named "about", which is served at the `/about` URL by default.
 
 ```run:command hidden=true cwd=super-rentals
 git add app/router.js
@@ -80,7 +80,7 @@ Speaking of the template, let's create that as well. We'll add a `app/templates/
 </div>
 ```
 
-Ember comes with strong *[conventions](TODO: link to conventions)* and sensible defaults &mdash; if we were starting from scratch, we wouldn't mind the default `/contact` URL. However, if the defaults don't work for us, it is no problem at all to customize Ember for our needs!
+Ember comes with strong *[conventions][TODO: link to conventions]* and sensible defaults &mdash; if we were starting from scratch, we wouldn't mind the default `/contact` URL. However, if the defaults don't work for us, it is no problem at all to customize Ember for our needs!
 
 Once you have added the route and the template above, we should have the new page available to us at `http://localhost:4200/getting-in-touch`.
 
@@ -90,9 +90,9 @@ git add app/templates/contact.hbs
 
 <!-- TODO: screenshot? -->
 
-We just put so much effort into making these pages, we need to make sure people can find them! The way we do that on the web is by using *[hyperlinks](TODO: link to hyperlinks)*, or *links* for short.
+We just put so much effort into making these pages, we need to make sure people can find them! The way we do that on the web is by using *[hyperlinks][TODO: link to hyperlinks]*, or *links* for short.
 
-Since Ember offers great support for URLs out-of-the-box, we _could_ just link our pages together using the `<a>` tag with the appropriate `href`. However, clicking on those links would require the browser to make a *[full-page refresh](TODO: link to full page refresh)*, which means that it would have to make a trip back to the server to fetch the page, and then load everything from scratch again.
+Since Ember offers great support for URLs out-of-the-box, we _could_ just link our pages together using the `<a>` tag with the appropriate `href`. However, clicking on those links would require the browser to make a *[full-page refresh][TODO: link to full page refresh]*, which means that it would have to make a trip back to the server to fetch the page, and then load everything from scratch again.
 
 With Ember, we can do better than that! Instead of the plain-old `<a>` tag, Ember provides an alternative called `<LinkTo>`. For example, here is how you would use it on the pages we just created:
 
@@ -119,15 +119,15 @@ With Ember, we can do better than that! Instead of the plain-old `<a>` tag, Embe
 
 There is quite a bit going on here, so let's break it down.
 
-`<LinkTo>` is an example of a *[component](TODO: link to component)* in Ember &mdash; you can tell them apart from regular HTML tags because they start with an uppercase letter. Along with regular HTML tags, components are a key building block that we can use to build up an app's user interface.
+`<LinkTo>` is an example of a *[component][TODO: link to component]* in Ember &mdash; you can tell them apart from regular HTML tags because they start with an uppercase letter. Along with regular HTML tags, components are a key building block that we can use to build up an app's user interface.
 
-We have a lot more to say about components later, but for now, you can think of them as a way to provide *[custom tags](TODO: link to custom tags)* to supplement the built-in ones that came with the browser.
+We have a lot more to say about components later, but for now, you can think of them as a way to provide *[custom tags][TODO: link to custom tags]* to supplement the built-in ones that came with the browser.
 
-The `@route=...` part is how we pass *[arguments](TODO: link to arguments)* into the component. Here, we use this to specify _which_ route we want to link to. Note that this should be the _name_ of the route, not the path, which is why we specified `"about"` instead of `"/about"`, and `"contact"` instead of `"/getting-in-touch"`.
+The `@route=...` part is how we pass *[arguments][TODO: link to arguments]* into the component. Here, we use this to specify _which_ route we want to link to. Note that this should be the _name_ of the route, not the path, which is why we specified `"about"` instead of `"/about"`, and `"contact"` instead of `"/getting-in-touch"`.
 
-In addition to arguments, components can also take the usual HTML attributes as well. In our example, we added a `"button"` class for styling purposes, but we could also specify other attributes as we see fit, such as the [ARIA](TODO: link to ARIA) [`role` attribute](TODO: link to role attribute). These are passed without the `@` symbol (`class=...` as opposed to `@class=...`), so that Ember will know they are just regular HTML attributes.
+In addition to arguments, components can also take the usual HTML attributes as well. In our example, we added a `"button"` class for styling purposes, but we could also specify other attributes as we see fit, such as the [ARIA][TODO: link to ARIA] [`role` attribute][TODO: link to role attribute]. These are passed without the `@` symbol (`class=...` as opposed to `@class=...`), so that Ember will know they are just regular HTML attributes.
 
-Under the hood, the `<LinkTo>` component generates a regular `<a>` tag for us with the appropriate `href` for the specific route. This allows for perfect interoperability for all *[screen readers](TODO: link to screen readers)*, as well as the ability for our users to bookmark the link or open it in a new tab.
+Under the hood, the `<LinkTo>` component generates a regular `<a>` tag for us with the appropriate `href` for the specific route. This allows for perfect interoperability for all *[screen readers][TODO: link to screen readers]*, as well as the ability for our users to bookmark the link or open it in a new tab.
 
 However, when clicking on one of these special links, Ember will intercept the click, render the content for the new page, and update the URL &mdash; all performed locally without having to wait for the server, thus avoiding a full page refresh.
 

--- a/src/chapters/03-automated-testing.md
+++ b/src/chapters/03-automated-testing.md
@@ -6,7 +6,7 @@ After all, most of us have experienced (or heard horror stories about) making a 
 
 Maybe we can write a checklist somewhere of all the things to check after making changes to our site. But surely, this will get out of hand as we add more features to our app. It is also going to get old really quickly &mdash; repetitive tasks like that are best left to robots.
 
-Hmm, robots. That's an idea. What if we can write this checklist and just get the computer to check everything for us? I think we just invented the idea of *[automated testing](TODO: link to automated testing)*!
+Hmm, robots. That's an idea. What if we can write this checklist and just get the computer to check everything for us? I think we just invented the idea of *[automated testing][TODO: link to automated testing]*!
 
 Okay, maybe we were not the first to come up with the concept, but we independently discovered it so we still deserve some credit. Once we are done patting ourselves on the back, go ahead and run the following command in the terminal:
 
@@ -14,7 +14,7 @@ Okay, maybe we were not the first to come up with the concept, but we independen
 ember generate acceptance-test super-rentals
 ```
 
-This is called a *[generator](TODO: link to generators)* command in Ember CLI. Generators automatically create files for us based on Ember's conventions and populate them with the appropriate boilerplate content, similar to how `ember new` initially created a skeleton app for us. It typically follows the pattern `ember generate <type> <name>`, where `<type>` is the kind of thing we are generating, and `<name>` is what we want to call it.
+This is called a *[generator][TODO: link to generators]* command in Ember CLI. Generators automatically create files for us based on Ember's conventions and populate them with the appropriate boilerplate content, similar to how `ember new` initially created a skeleton app for us. It typically follows the pattern `ember generate <type> <name>`, where `<type>` is the kind of thing we are generating, and `<name>` is what we want to call it.
 
 In this case, we generated an *[acceptance test][TODO: link to acceptance test]* located at `tests/acceptance/super-rentals-test.js`.
 
@@ -59,15 +59,15 @@ Let's open the generated test file and replace the boilerplate test with our own
 
 First, we instruct the test robot to navigate to the `/` URL of our app by using the `visit` _test helper_ provided by Ember. This is akin to us typing `http://localhost:4200/` in the browser's address bar and hitting the `enter` key.
 
-Because the page is going to take some time to load, this is known as an *[async](TODO: link to async)* (short for _asynchronous_) step, so we will need to tell the test robot to wait by using JavaScript's `await` keyword. That way, it will wait until the page completely finishes loading before moving on to the next step.
+Because the page is going to take some time to load, this is known as an *[async][TODO: link to async]* (short for _asynchronous_) step, so we will need to tell the test robot to wait by using JavaScript's `await` keyword. That way, it will wait until the page completely finishes loading before moving on to the next step.
 
 This is almost always the behavior we want, so we will almost always use `await` and `visit` as a pair. This applies to other kinds of simulated interaction too, such as clicking on a button or a link, as they all take time to complete. Even though sometimes these actions may seem imperceptibly fast to us, we have to remember that our test robot has really, really fast hands, as we will see in a moment.
 
-After navigating to the `/` URL and waiting for things to settle, we check that the current URL matches the URL that we expect (`/`). We can use the `currentURL` test helper here, as well as `equal` *[assertion](TODO: link to assertion)*. This is how we encode our "checklist" into code &mdash; by specifying, or *[asserting](TODO: link to asserting)* how things _should_ behave, we will be alerted if our app does _not_ behave in the way that we expect.
+After navigating to the `/` URL and waiting for things to settle, we check that the current URL matches the URL that we expect (`/`). We can use the `currentURL` test helper here, as well as `equal` *[assertion][TODO: link to assertion]*. This is how we encode our "checklist" into code &mdash; by specifying, or *[asserting][TODO: link to asserting]* how things _should_ behave, we will be alerted if our app does _not_ behave in the way that we expect.
 
 Next, we confirmed that the page has an `<h1>` tag that contains the text "Welcome to Super Rentals!". Knowing this is true means that we can be quite certain that the correct template has been rendered, without errors.
 
-Then, we looked for a link with the text `About Us`, located using the *[CSS selector](TODO: link to CSS selector)* `.jumbo a.button`. This is the same syntax we used in our stylesheet, which means "look inside the tag with the `jumbo` class for an `<a>` tag with the `button` class". This matches up with the HTML structure in our template.
+Then, we looked for a link with the text `About Us`, located using the *[CSS selector][TODO: link to CSS selector]* `.jumbo a.button`. This is the same syntax we used in our stylesheet, which means "look inside the tag with the `jumbo` class for an `<a>` tag with the `button` class". This matches up with the HTML structure in our template.
 
 Once the existence of this element on the page was confirmed, we told the test robot to click on this link. As mentioned above, this is a user interaction, so it needs to be `await`-ed.
 
@@ -82,7 +82,7 @@ yarn test
 git add tests/acceptance/super-rentals-test.js
 ```
 
-We can put our automated test into motion by running the *[test server](TODO: link to test server)* using the `ember test --server` command, or `ember t -s` for short. This server behaves much like the development server, but it is explicitly running for our tests. It may automatically open a browser window and take you to the test UI, or you can open `http://localhost:7357/` yourself.
+We can put our automated test into motion by running the *[test server][TODO: link to test server]* using the `ember test --server` command, or `ember t -s` for short. This server behaves much like the development server, but it is explicitly running for our tests. It may automatically open a browser window and take you to the test UI, or you can open `http://localhost:7357/` yourself.
 
 If you watch really carefully, you can see our test robot roam around our app and clicking links:
 
@@ -90,7 +90,7 @@ If you watch really carefully, you can see our test robot roam around our app an
 
 It happens really quickly though &mdash; blink and you might miss it! In fact, I had to slow this animation down by a hundred times just so you can see it in action. I told you the robot has really, really fast hands!
 
-As much as I enjoy watching this robot hard at work, the important thing here is that the test we wrote has *[passed](TODO: link to passed)*, meaning everything is working exactly as we expect and the test UI is all green and happy. If you want, you can go to `index.hbs`, delete the `<LinkTo>` component and see what things look like when we have *[a failing test](TODO: link to a failing test)*.
+As much as I enjoy watching this robot hard at work, the important thing here is that the test we wrote has *[passed][TODO: link to passed]*, meaning everything is working exactly as we expect and the test UI is all green and happy. If you want, you can go to `index.hbs`, delete the `<LinkTo>` component and see what things look like when we have *[a failing test][TODO: link to a failing test]*.
 
 <!-- TODO: animated gif -->
 
@@ -135,7 +135,7 @@ yarn test
 git add tests/acceptance/super-rentals-test.js
 ```
 
-For the rest of the tutorial, we will continue to add more automated tests as we develop new features. Testing is optional; tests don't affect the functionality your app, they just protect it from *[regressions](TODO: link to regressions)*, which is just a fancy way of saying "accidental breakages."
+For the rest of the tutorial, we will continue to add more automated tests as we develop new features. Testing is optional; tests don't affect the functionality your app, they just protect it from *[regressions][TODO: link to regressions]*, which is just a fancy way of saying "accidental breakages."
 
 If you are in a hurry, you can skip over the testing sections in this tutorial and still be able to follow along with everything else. But don't you find it super satisfying &mdash; _oddly satisfying_ &mdash; to watch a robot click on things really, really fast?
 

--- a/src/chapters/04-component-basics.md
+++ b/src/chapters/04-component-basics.md
@@ -1,4 +1,4 @@
-In a [previous chapter](../02-building-pages), we got a light introduction to *[components](TODO: link to components)* when using `<LinkTo>` to connect our pages. To recap, we said that components are Ember's way of creating *[custom tags](TODO: link to custom tags)* to supplement the built-in HTML tags from the browser. Now, we are going to create our own components!
+In a [previous chapter](../02-building-pages), we got a light introduction to *[components][TODO: link to components]* when using `<LinkTo>` to connect our pages. To recap, we said that components are Ember's way of creating *[custom tags][TODO: link to custom tags]* to supplement the built-in HTML tags from the browser. Now, we are going to create our own components!
 
 During the course of developing an app, it is pretty common to reuse the same UI element across different parts of the app. For example, we have been using the same "jumbo" header in all three pages so far. On every page we worked to follow the same basic structure:
 
@@ -24,13 +24,13 @@ Components are the perfect solution to this. In its most basic form, a component
 git add app/components/jumbo.hbs
 ```
 
-That's it, we have created our first component! We can now *[invoke](TODO: link to invoke)* this component anywhere in our app, using `<Jumbo>` as the tag name.
+That's it, we have created our first component! We can now *[invoke][TODO: link to invoke]* this component anywhere in our app, using `<Jumbo>` as the tag name.
 
 > Zoey says...
 >
 > Remember, when invoking components, we need to capitalize their names so Ember can tell them apart from regular HTML elements. The `jumbo.hbs` template corresponds to the `<Jumbo>` tag, just like `super-awesome.hbs` corresponds to `<SuperAwesome>`.
 
-When invoking a component, Ember will replace the component tag with the content found in the component's template. Just like regular HTML tags, it is common to pass *[content](TODO: link to content)* to components, like `<Jumbo>some content</Jumbo>`. We can enable this using the `{{yield}}` keyword, which will be replaced with the content that was passed to the component.
+When invoking a component, Ember will replace the component tag with the content found in the component's template. Just like regular HTML tags, it is common to pass *[content][TODO: link to content]* to components, like `<Jumbo>some content</Jumbo>`. We can enable this using the `{{yield}}` keyword, which will be replaced with the content that was passed to the component.
 
 Let's try it out by editing the index template:
 
@@ -46,7 +46,7 @@ Let's try it out by editing the index template:
 +</Jumbo>
 ```
 
-After saving the changes, your page should automatically reload, and, _voilà_... nothing changed? Well, that's exactly what we wanted to happen this time! We successfully *[refactored](TODO: link to refactored)* our index template to use the `<Jumbo>` component, and everything still works as expected. And the tests still pass!
+After saving the changes, your page should automatically reload, and, _voilà_... nothing changed? Well, that's exactly what we wanted to happen this time! We successfully *[refactored][TODO: link to refactored]* our index template to use the `<Jumbo>` component, and everything still works as expected. And the tests still pass!
 
 <!-- TODO: screenshot of running tests? -->
 
@@ -92,7 +92,7 @@ git add app/templates/contact.hbs
 
 After saving, everything should look exactly the same as before, and all the tests should still pass. Very nice!
 
-While it may not save you a lot of characters in this case, [encapsulating](TODO: link to encapsulating)* the implementation of the "jumbo" header into its own component makes the template slightly easier to read, as it allows the reader to focus on things that are unique to just that page. Further, if we need to make a change to the header, we can make it in a single place. Feel free to give that a try!
+While it may not save you a lot of characters in this case, [encapsulating][TODO: link to encapsulating]* the implementation of the "jumbo" header into its own component makes the template slightly easier to read, as it allows the reader to focus on things that are unique to just that page. Further, if we need to make a change to the header, we can make it in a single place. Feel free to give that a try!
 
 Before we move on to the next component, let's write an automated test for our `<Jumbo>` component. Run this command in your terminal:
 
@@ -104,7 +104,7 @@ ember generate component-test jumbo
 git add tests/integration/components/jumbo-test.js
 ```
 
-Here, we used the generator to generate a *[component test](TODO: link to component test)*. These are used to render and test a single component at a time. This is in contrast to the acceptance tests that we wrote earlier, which have to navigate and render entire pages worth of content.
+Here, we used the generator to generate a *[component test][TODO: link to component test]*. These are used to render and test a single component at a time. This is in contrast to the acceptance tests that we wrote earlier, which have to navigate and render entire pages worth of content.
 
 Let's replace the boilerplate code that was generated for us with our own test:
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,2 +1,3 @@
 export { default as runCodeBlocks } from './plugins/run-code-blocks';
+export { default as todoLinks } from './plugins/todo-links';
 export { default as zoeySays } from './plugins/zoey-says';

--- a/src/lib/plugins/todo-links/index.ts
+++ b/src/lib/plugins/todo-links/index.ts
@@ -1,0 +1,15 @@
+import { Plugin, Transformer } from 'unified';
+import { Node } from 'unist';
+import Walker from './walker';
+
+function attacher(): Transformer {
+  async function transform(node: Node): Promise<Node> {
+    return new Walker().walk(node);
+  }
+
+  return transform;
+}
+
+const plugin: Plugin<[]> = attacher;
+
+export default plugin;

--- a/src/lib/plugins/todo-links/walker.ts
+++ b/src/lib/plugins/todo-links/walker.ts
@@ -1,0 +1,26 @@
+import { Association, LinkReference, StaticPhrasingContent } from 'mdast';
+import BaseWalker from '../../walker';
+
+const TODO_PREFIX = 'TODO:';
+
+function isTodoLink(node: LinkReference): boolean {
+  // This is a bug in `mdast`.
+  // According to the spec, Reference extends Association.
+  // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/37882
+  let { label } = node as LinkReference & Association;
+  return !!label && label.startsWith(TODO_PREFIX);
+}
+
+export default class TodoLinksWalker extends BaseWalker<null> {
+  constructor() {
+    super(null);
+  }
+
+  protected async linkReference(node: LinkReference): Promise<LinkReference | StaticPhrasingContent[]> {
+    if (isTodoLink(node)) {
+      return node.children;
+    } else {
+      return node;
+    }
+  }
+}

--- a/src/lib/plugins/zoey-says/walker.ts
+++ b/src/lib/plugins/zoey-says/walker.ts
@@ -44,7 +44,7 @@ async function render(nodes: BlockContent[], position?: Position): Promise<HTML>
   return { type: 'html', value, position };
 }
 
-export default class Walker extends BaseWalker<null> {
+export default class ZoeySaysWalker extends BaseWalker<null> {
   constructor() {
     super(null);
   }


### PR DESCRIPTION
This requires using the `[some text][TODO: some comment]` syntax instead, because the `[some text](TODO: some comment)` syntax parsed into a `LinkReference` (`[some text]`) plus a regular `Text` node (`"(TODO: some comment)"`) as siblings.