### PR TITLE
Optimize screenshots

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
       - fonts-liberation
       - libappindicator3-1
       - libnss3
+      - optipng
       - xdg-utils
   chrome: stable
 
@@ -37,6 +38,7 @@ script:
 
 before_deploy:
   - openssl aes-256-cbc -K $encrypted_abcbee76306e_key -iv $encrypted_abcbee76306e_iv -in deploy-keys.tar.gz.enc -out deploy-keys.tar.gz -d
+  - optipng -o5 dist/assets/screenshots/**/*.png
 
 deploy:
   provider: script


### PR DESCRIPTION
I'm not sure if `-o5` is the right tradeoff. If it's too slow I think we can probably dial it down without much impact on the compression result.