### PR TITLE
Deterministic builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
       # These are for optimizing screenshots
       - advancecomp
       - optipng
+      - perceptualdiff
   chrome: stable
 
 cache:
@@ -40,8 +41,6 @@ script:
 
 before_deploy:
   - openssl aes-256-cbc -K $encrypted_abcbee76306e_key -iv $encrypted_abcbee76306e_iv -in deploy-keys.tar.gz.enc -out deploy-keys.tar.gz -d
-  - find dist/assets/screenshots -type f -name "*.png" | xargs -t -P 2 -n 1 optipng -q -o5
-  - find dist/assets/screenshots -type f -name "*.png" | xargs -t -P 2 -n 1 advpng -z -q -4
 
 deploy:
   provider: script

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -62,6 +62,8 @@ rm -rf guides/release/tutorial/*
 cp -r ../../dist/chapters/* guides/release/tutorial/
 git add guides/release/tutorial
 cp -r ../../dist/assets/* public/
+rm -rf public/screenshots
+find ../../dist/assets/screenshots -type f -name "*.png" | xargs -n 1 ../../scripts/optimize-screenshot.sh
 git add public
 if git diff --cached --exit-code; then
   echo "Nothing to push"

--- a/scripts/optimize-screenshot.sh
+++ b/scripts/optimize-screenshot.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+SRC="$1"
+DEST=$(echo -n "$1" | sed "s|../../dist/assets/|public/|")
+
+if git checkout -- "$DEST" > /dev/null 2>&1; then
+  if perceptualdiff "$SRC" "$DEST" > /dev/null; then
+    echo "$DEST (unchanged)"
+    exit 0
+  fi
+else
+  mkdir -p "$(dirname "$DEST")"
+fi
+
+cp "$SRC" "$DEST"
+optipng -q -o5 "$DEST"
+advpng -z -q -4 "$DEST"
+
+BEFORE=$(wc -c < "$SRC")
+AFTER=$(wc -c < "$DEST")
+PERCENTAGE=$(( $AFTER * 100 / $BEFORE ))
+
+echo "$DEST ($PERCENTAGE%)"
+exit 0

--- a/src/bin/generate.ts
+++ b/src/bin/generate.ts
@@ -35,7 +35,7 @@ async function main() {
 
   const processor = unified()
     .use(markdown)
-    .use(runCodeBlocks, { cwd: codeDir, assets: assetsDir })
+    .use(runCodeBlocks, { cfg: process.env.CI ? ['ci'] : [], cwd: codeDir, assets: assetsDir })
     .use(todoLinks)
     .use(zoeySays)
     .use(doNotEdit, { repo: 'ember-learn/super-rentals-tutorial' })

--- a/src/chapters/03-automated-testing.md
+++ b/src/chapters/03-automated-testing.md
@@ -93,7 +93,7 @@ If you watch really carefully, you can see our test robot roam around our app an
 <!-- TODO: make this a gif instead -->
 
 ```run:screenshot width=1024 height=512 retina=true filename=pass.png alt="All tests passing"
-visit http://localhost:4200/tests?nocontainer
+visit http://localhost:4200/tests?nocontainer&deterministic
 wait  #qunit-banner.qunit-pass
 ```
 
@@ -109,7 +109,7 @@ As much as I enjoy watching this robot hard at work, the important thing here is
 ```
 
 ```run:screenshot width=1024 height=768 retina=true filename=fail.png alt="A failing test"
-visit http://localhost:4200/tests?nocontainer
+visit http://localhost:4200/tests?nocontainer&deterministic
 wait  #qunit-banner.qunit-fail
 ```
 
@@ -155,7 +155,7 @@ Let's practice what we learned by adding tests for the remaining pages:
 As with the development server, the test UI should automatically reload and rerun the entire test suite as you save the files. It is recommended that you keep this page open as you develop your app. That way, you will get immediate feedback if you accidentally break something.
 
 ```run:screenshot width=1024 height=512 retina=true filename=pass-2.png alt="Tests still passing with the new tests"
-visit http://localhost:4200/tests?nocontainer
+visit http://localhost:4200/tests?nocontainer&deterministic
 wait  #qunit-banner.qunit-pass
 ```
 

--- a/src/chapters/04-component-basics.md
+++ b/src/chapters/04-component-basics.md
@@ -57,7 +57,7 @@ visit http://localhost:4200/
 ```
 
 ```run:screenshot width=1024 height=512 retina=true filename=pass.png alt="Tests still passing after the refactor"
-visit http://localhost:4200/tests?nocontainer
+visit http://localhost:4200/tests?nocontainer&deterministic
 wait  #qunit-banner.qunit-pass
 ```
 
@@ -113,7 +113,7 @@ visit http://localhost:4200/getting-in-touch
 ```
 
 ```run:screenshot width=1024 height=512 retina=true filename=pass-2.png alt="Tests still passing another round of refactor"
-visit http://localhost:4200/tests?nocontainer
+visit http://localhost:4200/tests?nocontainer&deterministic
 wait  #qunit-banner.qunit-pass
 ```
 
@@ -171,7 +171,7 @@ git add tests/integration/components/jumbo-test.js
 ```
 
 ```run:screenshot width=1024 height=512 retina=true filename=pass-3.png alt="Tests still passing with our component test"
-visit http://localhost:4200/tests?nocontainer
+visit http://localhost:4200/tests?nocontainer&deterministic
 wait  #qunit-banner.qunit-pass
 ```
 
@@ -288,7 +288,7 @@ git add tests/acceptance/super-rentals-test.js
 ```
 
 ```run:screenshot width=1024 height=512 retina=true filename=pass-4.png alt="Tests still passing with our <NavBar> tests"
-visit http://localhost:4200/tests?nocontainer
+visit http://localhost:4200/tests?nocontainer&deterministic
 wait  #qunit-banner.qunit-pass
 ```
 
@@ -341,7 +341,7 @@ git add app/templates/about.hbs
 ```
 
 ```run:screenshot width=1024 height=512 retina=true filename=pass-5.png alt="Tests still passing with {{outlet}}"
-visit http://localhost:4200/tests?nocontainer
+visit http://localhost:4200/tests?nocontainer&deterministic
 wait  #qunit-banner.qunit-pass
 ```
 

--- a/src/lib/plugins/run-code-blocks/cfg.ts
+++ b/src/lib/plugins/run-code-blocks/cfg.ts
@@ -1,0 +1,98 @@
+import { Option } from 'ts-std';
+import ParseError from './parse-error';
+
+export interface ConfigurationPredicate {
+  eval(cfg: string[]): boolean;
+}
+
+class ConfigurationOption implements ConfigurationPredicate {
+  static parse(input: string, lineno: Option<number>): ConfigurationOption {
+    if (input === '' || /\(|\)|,/.test(input)) {
+      throw new ParseError('expecting a single cfg predicate', lineno);
+    }
+
+    return new this(input);
+  }
+
+  private constructor(private option: string) {}
+
+  eval(cfg: string[]): boolean {
+    return cfg.includes(this.option);
+  }
+}
+
+class ConfigurationAll implements ConfigurationPredicate {
+  static parse(input: string, lineno: Option<number>): Option<ConfigurationAll> {
+    let match = /^all\((.+)\)$/.exec(input);
+
+    if (match) {
+      return new this(parsePredicates(match[1], lineno));
+    } else {
+      return null;
+    }
+  }
+
+  private constructor(private predicates: ConfigurationPredicate[]) {}
+
+  eval(cfg: string[]): boolean {
+    return this.predicates.every(p => p.eval(cfg));
+  }
+}
+
+class ConfigurationAny implements ConfigurationPredicate {
+  static parse(input: string, lineno: Option<number>): Option<ConfigurationAny> {
+    let match = /^any\((.+)\)$/.exec(input);
+
+    if (match) {
+      return new this(parsePredicates(match[1], lineno));
+    } else {
+      return null;
+    }
+  }
+
+  private constructor(private predicates: ConfigurationPredicate[]) {}
+
+  eval(cfg: string[]): boolean {
+    return this.predicates.some(p => p.eval(cfg));
+  }
+}
+
+class ConfigurationNot implements ConfigurationPredicate {
+  static parse(input: string, lineno: Option<number>): Option<ConfigurationNot> {
+    let match = /^not\((.+)\)$/.exec(input);
+
+    if (match) {
+      return new this(parse(match[1], lineno));
+    } else {
+      return null;
+    }
+  }
+
+  private constructor(private predicate: ConfigurationPredicate) {}
+
+  eval(cfg: string[]): boolean {
+    return !this.predicate.eval(cfg);
+  }
+}
+
+export default function parse(input: string, lineno: Option<number>): ConfigurationPredicate {
+  return ConfigurationAll.parse(input, lineno) ||
+    ConfigurationAny.parse(input, lineno) ||
+    ConfigurationNot.parse(input, lineno) ||
+    ConfigurationOption.parse(input, lineno);
+}
+
+function parsePredicates(input: string, lineno: Option<number>): ConfigurationPredicate[] {
+  let items = input.split(',').map(item => item.trim());
+
+  // Trailing comma
+  if (items.length > 0 && items[items.length - 1] === '') {
+    items.pop();
+  }
+
+  if (items.length === 0) {
+    throw new ParseError('expecting at least one cfg predicate', lineno);
+  }
+
+  return items.map(item => parse(item, lineno));
+}

--- a/src/lib/plugins/run-code-blocks/commands.ts
+++ b/src/lib/plugins/run-code-blocks/commands.ts
@@ -1,0 +1,128 @@
+import { Option } from 'ts-std';
+import parseCfg, { ConfigurationPredicate } from './cfg';
+import LineNo, { end, offset } from './lineno';
+import ParseError from './parse-error';
+
+export class Command {
+  constructor(readonly command: string, readonly display: string) {}
+}
+
+interface PartialCommand {
+  cfg?: ConfigurationPredicate;
+  display?: string;
+  command?: string;
+}
+
+export function parseCommands(input: string, cfg: string[], lineno: LineNo): Command[] {
+  let commands: Command[] = [];
+
+  let current: Option<PartialCommand> = null;
+
+  let initialize = (): PartialCommand => {
+    if (current === null) {
+      current = {};
+    }
+
+    return current;
+  };
+
+  let finalize = (ln: LineNo) => {
+    if (!current) {
+      return;
+    }
+
+    if (current.command === undefined) {
+      throw new ParseError('expecting command', ln);
+    }
+
+    if (current.command.trimRight().endsWith('\\')) {
+      throw new ParseError('expecting command (invalid line-continuation)', ln);
+    }
+
+    if (current.cfg && !current.cfg.eval(cfg)) {
+      current = null;
+      return;
+    }
+
+    commands.push(new Command(current.command, current.display || current.command));
+    current = null;
+  };
+
+  let lines = input.split('\n');
+
+  for (let [i, line] of lines.entries()) {
+    let ln = offset(lineno, i + 1);
+
+    if (line.trim() === '') {
+      finalize(ln);
+      continue;
+    }
+
+    let config = /^#\[cfg\((.+)\)\]$/.exec(line);
+
+    if (config) {
+      let partial = initialize();
+
+      if (partial.cfg !== undefined) {
+        throw new ParseError('only one `#[cfg(...)]` allowed per command', ln);
+      }
+
+      partial.cfg = parseCfg(config[1], ln);
+
+      continue;
+    }
+
+    let display = /^#\[display\((.+)\)\]$/.exec(line);
+
+    if (display) {
+      let partial = initialize();
+
+      if (partial.display !== undefined) {
+        throw new ParseError('only one `#[display(...)]` allowed for each command', ln);
+      }
+
+      partial.display = display[1];
+
+      continue;
+    }
+
+    let unknown = /^#\[.+\]$/.exec(line);
+
+    if (unknown) {
+      throw new ParseError(`invalid directive \`${line}\``, ln);
+    }
+
+    if (line.startsWith('#')) {
+      finalize(ln);
+      continue;
+    }
+
+    {
+      let partial = initialize();
+
+      if (partial.command) {
+        partial.command = `${partial.command}\n${line}`;
+      } else {
+        partial.command = line;
+      }
+
+      if (!partial.command.trimRight().endsWith('\\')) {
+        finalize(ln);
+      }
+    }
+  }
+
+  finalize(lines.length);
+
+  return commands;
+}
+
+export function parseCommand(input: string, cfg: string[], lineno: LineNo): Command {
+  let commands = parseCommands(input, cfg, lineno);
+
+  if (commands.length === 1) {
+    return commands[0];
+  } else {
+    throw new ParseError(`expecting exactly 1 command, got ${commands.length}`, end(lineno));
+  }
+}

--- a/src/lib/plugins/run-code-blocks/directives/command.ts
+++ b/src/lib/plugins/run-code-blocks/directives/command.ts
@@ -3,6 +3,7 @@ import { Code } from 'mdast';
 import { join } from 'path';
 import { Option } from 'ts-std';
 import { promisify } from 'util';
+import { parseCommands } from '../commands';
 import Options from '../options';
 import parseArgs, { ToBool, optional } from '../parse-args';
 
@@ -12,11 +13,6 @@ interface Args {
   hidden?: boolean;
   cwd?: string;
   captureOutput?: boolean;
-}
-
-export function parseCommands(commands: string): string[] {
-  return commands.split(/(?<!\\)\n/)
-    .filter(line => line && !line.startsWith('#'));
 }
 
 export default async function command(node: Code, options: Options): Promise<Option<Code>> {
@@ -38,9 +34,9 @@ export default async function command(node: Code, options: Options): Promise<Opt
 
   let output = [];
 
-  for (let cmd of parseCommands(node.value)) {
+  for (let { command: cmd, display } of parseCommands(node.value, options.cfg, node)) {
     console.log(`$ ${cmd}`);
-    output.push(`$ ${cmd}`);
+    output.push(`$ ${display}`);
 
     let { stdout } = await exec(cmd, { cwd });
 

--- a/src/lib/plugins/run-code-blocks/directives/file/patch.ts
+++ b/src/lib/plugins/run-code-blocks/directives/file/patch.ts
@@ -21,11 +21,7 @@ function formatPatch(patch: string, filename?: string): string {
     patch = `--- a/${filename}\n+++ b/${filename}\n${patch}`;
   }
 
-  if (!patch.endsWith('\n')) {
-    patch = `${patch}\n`;
-  }
-
-  return patch;
+  return `${patch}\n`;
 }
 
 async function applyPatch(patch: string, cwd: string): Promise<void> {

--- a/src/lib/plugins/run-code-blocks/directives/server/stop.ts
+++ b/src/lib/plugins/run-code-blocks/directives/server/stop.ts
@@ -1,19 +1,19 @@
 import { Code } from 'mdast';
+import { parseCommand } from '../../commands';
 import Options from '../../options';
 import parseArgs, { optional } from '../../parse-args';
 import Servers from '../../servers';
-import { parseCommand } from './start';
 
 interface Args {
   id?: string;
 }
 
-export default async function stopServer(node: Code, _options: Options, servers: Servers): Promise<null> {
+export default async function stopServer(node: Code, options: Options, servers: Servers): Promise<null> {
   let args = parseArgs<Args>(node, [
     optional('id', String)
   ]);
 
-  let id = args.id || parseCommand(node.value);
+  let id = args.id || parseCommand(node.value, options.cfg, node).display;
   let server = servers.remove(id);
 
   try {

--- a/src/lib/plugins/run-code-blocks/index.ts
+++ b/src/lib/plugins/run-code-blocks/index.ts
@@ -4,9 +4,21 @@ import { VFile } from 'vfile';
 import Options from './options';
 import Walker from './walker';
 
+function normalizeOptions(options: Options): Options {
+  let cfg = [...options.cfg, process.platform];
+
+  if (process.platform === 'win32') {
+    cfg.push('windows');
+  } else {
+    cfg.push('unix');
+  }
+
+  return { ...options, cfg };
+}
+
 function attacher(options: Options): Transformer {
   async function transform(node: Node, file: VFile): Promise<Node> {
-    return new Walker(options, file).walk(node);
+    return new Walker(normalizeOptions(options), file).walk(node);
   }
 
   return transform;

--- a/src/lib/plugins/run-code-blocks/lineno.ts
+++ b/src/lib/plugins/run-code-blocks/lineno.ts
@@ -1,0 +1,38 @@
+import { Option } from 'ts-std';
+import { Node } from 'unist';
+
+type LineNo = Option<number | Node>;
+export default LineNo;
+
+export function isNumber(lineno: LineNo): lineno is number {
+  return typeof lineno === 'number';
+}
+
+export function isNode(lineno: LineNo): lineno is Node {
+  return lineno !== null && !isNumber(lineno);
+}
+
+export function start(lineno: LineNo): Option<number> {
+  if (isNumber(lineno)) {
+    return lineno;
+  } else if (isNode(lineno) && lineno.position) {
+    return lineno.position.start.line;
+  } else {
+    return null;
+  }
+}
+
+export function end(lineno: LineNo): Option<number> {
+  if (isNumber(lineno)) {
+    return lineno;
+  } else if (isNode(lineno) && lineno.position) {
+    return lineno.position.end.line;
+  } else {
+    return null;
+  }
+}
+
+export function offset(lineno: LineNo, i: number): Option<number> {
+  let v = start(lineno);
+  return v === null ? null : v + i;
+}

--- a/src/lib/plugins/run-code-blocks/options.ts
+++ b/src/lib/plugins/run-code-blocks/options.ts
@@ -1,4 +1,5 @@
 export default interface Options {
+  cfg: string[];
   cwd: string;
   assets: string;
 }

--- a/src/lib/plugins/run-code-blocks/parse-args.ts
+++ b/src/lib/plugins/run-code-blocks/parse-args.ts
@@ -1,5 +1,6 @@
 import { Code } from 'mdast';
 import { assert, dict } from 'ts-std';
+import ParseError from './parse-error';
 
 export type Transform<From, To> = (input: From) => To;
 
@@ -39,12 +40,16 @@ export default function parseArgs<Args extends object>(node: Code, transforms: K
     while (pattern.lastIndex < meta.length) {
       let match = pattern.exec(meta);
 
-      assert(match !== null, `Invalid arguments for \`${lang}\`: ${meta}`);
+      if (match === null) {
+        throw new ParseError(`invalid arguments for \`${lang}\`: ${meta}`, node);
+      }
 
-      let [, key, v1, v2, v3] = match!;
+      let [, key, v1, v2, v3] = match;
       let value = v1 || v2 || v3;
 
-      assert(validKeys.includes(key), `\`${key}\` is not a valid argument for \`${lang}\``);
+      if (!validKeys.includes(key)) {
+        throw new ParseError(`\`${key}\` is not a valid argument for \`${lang}\``, node);
+      }
 
       parsed[key] = value;
     }

--- a/src/lib/plugins/run-code-blocks/parse-error.ts
+++ b/src/lib/plugins/run-code-blocks/parse-error.ts
@@ -1,0 +1,13 @@
+import LineNo, { start } from './lineno';
+
+export default class ParseError extends Error {
+  constructor(reason: string, lineno: LineNo) {
+    let line = start(lineno);
+
+    if (line) {
+      super(`${reason} (on line ${line})`);
+    } else {
+      super(reason);
+    }
+  }
+}


### PR DESCRIPTION
Attempt to ensure the markdown and screenshots doesn't produce slightly different results on each build.

Currently, the main sources of diffs come from timing information. Specifically:

1. The "Build successful (9761ms)" message in the `ember server` output

2. The QUnit test timing information in the screenshots

This commit introduce some new facilities to help scrub these incidental sources of indeterminism.

As part of this, we can also use said facilities to improve Windows compatibility.

It should also significantly improve deploy speed on master, since most of the time we won't have to spend 10+ minutes compressing PNGs that barely changed.