### PR TITLE
Tell the user to go into the super-rentals dir

### DIFF
--- a/src/chapters/01-orientation.md
+++ b/src/chapters/01-orientation.md
@@ -120,6 +120,8 @@ del package.json
 
 ```
 
+After creating the repository from the [ember-cli](https://ember-cli.com/) `new` command, navigate into it.
+
 ```shell
 $ cd super-rentals
 ```

--- a/src/chapters/01-orientation.md
+++ b/src/chapters/01-orientation.md
@@ -120,6 +120,10 @@ del package.json
 
 ```
 
+```shell
+$ cd super-rentals
+```
+
 ```run:command hidden=true cwd=super-rentals
 yarn test
 git add tests/index.html


### PR DESCRIPTION
We end up adding `cwd=super-rentals` to all the run commands after this but we never tell the user