### PR TITLE
Fix for sh

### DIFF
--- a/src/chapters/01-orientation.md
+++ b/src/chapters/01-orientation.md
@@ -150,9 +150,11 @@ For the rest of the tutorial, all commands should be run within the `super-renta
 # Also, try to hide yarn.lock from view and fake a package-lock.json
 
 #[cfg(unix)]
-tree super-rentals -a -I "node_modules|.git|yarn.lock" --dirsfirst | \
-  sed 's/\xC2\xA0/ /g' | \
-  sed $'s/^\\(.*\\)package\\.json$/\\1package.json\\\n\\1package-lock.json/g'
+tree super-rentals -a -I "node_modules|.git|yarn.lock" --dirsfirst \
+  | sed 's/\xC2\xA0/ /g' \
+  | awk \
+    '/package\.json/ { print $1 " package.json"; print $1 " package-lock.json" } \
+    !/package\.json/ { print }'
 
 #[cfg(windows)]
 tree super-rentals /F


### PR DESCRIPTION
`$'...'` is valid in bash, but not in sh (which is the default shell for running these commands).