### PR TITLE
Fix `yarn start` in `ember new` output

### DIFF
--- a/src/chapters/01-orientation.md
+++ b/src/chapters/01-orientation.md
@@ -27,7 +27,7 @@ echo "{}" > package.json
 #[cfg(all(ci, unix))]
 #[display(ember new super-rentals -b @ember/octane-app-blueprint)]
 ember new super-rentals --yarn -b @ember/octane-app-blueprint \
-  | awk '{ gsub("Yarn", "npm"); print }'
+  | awk '{ gsub("Yarn", "npm"); gsub("yarn", "npm"); print }'
 
 #[cfg(not(all(ci, unix)))]
 ember new super-rentals --yarn -b @ember/octane-app-blueprint


### PR DESCRIPTION
The upstream bug has been fixed in https://github.com/ember-cli/ember-cli/pull/8862 (ember-cli 3.13.1)