### PR TITLE
Remove alt text for decorative image

### DIFF
--- a/src/lib/plugins/zoey-says/walker.ts
+++ b/src/lib/plugins/zoey-says/walker.ts
@@ -38,7 +38,7 @@ async function render(nodes: BlockContent[], position?: Position): Promise<HTML>
         ${content.join('        \n')}
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>`;
 


### PR DESCRIPTION
According to https://www.w3.org/WAI/tutorials/images/decorative/, decorative images should have `alt=""`.