### PR TITLE
Fix bug in screenshot DSL parsing

### DIFF
--- a/src/chapters/06-interactive-components.md
+++ b/src/chapters/06-interactive-components.md
@@ -207,7 +207,7 @@ With that, we have created our first *[interactive][TODO: link to interactive]* 
 
 <!-- TODO: make this a gif instead -->
 
-```run:screenshot width=1024 height=1500 retina=true filename=rental-image-default.png alt="<Rental::Image> (default size)"
+```run:screenshot width=1024 retina=true filename=rental-image-default.png alt="<Rental::Image> (default size)"
 visit http://localhost:4200/
 wait  .rentals li:nth-of-type(3) article.rental .image img
 ```
@@ -215,7 +215,7 @@ wait  .rentals li:nth-of-type(3) article.rental .image img
 ```run:screenshot width=1024 height=1500 retina=true filename=rental-image-large.png alt="<Rental::Image> (large size)"
 visit http://localhost:4200/
 wait  .rentals li:nth-of-type(3) article.rental .image img
-click .rentals li:first-of-type article.rental .image img
+click .rentals li:first-of-type article.rental .image
 wait  .rentals li:first-of-type article.rental .image.large img
 ```
 

--- a/src/lib/plugins/run-code-blocks/directives/screenshot.ts
+++ b/src/lib/plugins/run-code-blocks/directives/screenshot.ts
@@ -71,7 +71,8 @@ async function main() {
       continue;
     }
 
-    let [action, arg] = step.split(/\s+/, 2);
+    let [action, ...rest] = step.split(/\s+/);
+    let arg = rest.join(' ');
 
     switch (action) {
       case 'click':


### PR DESCRIPTION
I guess I was expecting `String.prototype.split` to work this way:

```js
> "click .rentals li:first-of-type article.rental .image".split(/\s+/, 2);
[ 'click', 'rentals li:first-of-type article.rental .image' ]
```

But it does not, it returns this:

```js
> "click .rentals li:first-of-type article.rental .image".split(/\s+/, 2);
[ 'click', '.rentals' ]
```

TL;DR I was expecting the limit parameter to mean that it will only split the first space, and the rest will be returned unspilt (like how it is in Ruby). However, it actually just split all the spaces anyway, the "extra" strings are just dropped from the returned array.