### PR TITLE
Use regex correctly (－‸ლ)

### DIFF
--- a/src/lib/plugins/retina-images/walker.ts
+++ b/src/lib/plugins/retina-images/walker.ts
@@ -20,7 +20,7 @@ async function isRetinaImage(src: string, options: Options): Promise<boolean> {
 }
 
 function attr(v: unknown): string {
-  let escaped = String(v).replace(/<>"/g, c => {
+  let escaped = String(v).replace(/[<>"]/g, c => {
     switch (c) {
       case '<':
         return '&lt;';


### PR DESCRIPTION
The previous code didn't work correctly because it was trying to replace `<>"`, not (`<` or `>` or `"`).