### PR TITLE
Add note about mapbox token to README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ env:
   global:
     - VOLTA_HOME=/home/travis/.volta/
     - PATH=$VOLTA_HOME/bin:$PATH
-    # This is needed for external PRs to build, since secure ENV don't apply for those
+    # This is needed for external PRs to build, since secure ENV don't apply to those
     # Get your own token at https://account.mapbox.com/access-tokens
     - MAPBOX_ACCESS_TOKEN="pk.eyJ1IjoiZW1iZXJqcyIsImEiOiJjazBydnZjb2wwYXA5M2Rwc3IydGF2eXM0In0.EQiBFsRi9Jm70XFPiXnoHg"
 

--- a/README.md
+++ b/README.md
@@ -596,6 +596,7 @@ Options:
   * Should probably run the build in a docker container anyway
 * `yarn install`
 * `yarn build`
+  * Please note that you will need a Mapbox token in order to successfully run `yarn build`. You can get your own token [here](https://account.mapbox.com/access-tokens). Once you have a token, you can build the project by running `MAPBOX_ACCESS_TOKEN=your-token-here yarn build`.
 * Processed markdown can be found in `dist/chapters`
 * The `super-rentals` code can be found in `dist/code/super-rentals`
 

--- a/README.md
+++ b/README.md
@@ -595,8 +595,8 @@ Options:
 * Probably only works on unix/bash for now (PRs welcome)
   * Should probably run the build in a docker container anyway
 * `yarn install`
-* `yarn build`
-  * Please note that you will need a Mapbox token in order to successfully run `yarn build`. You can get your own token [here](https://account.mapbox.com/access-tokens). Once you have a token, you can build the project by running `MAPBOX_ACCESS_TOKEN=your-token-here yarn build`.
+* `MAPBOX_ACCESS_TOKEN=your-token-here yarn build`
+  * Please note that you will need a Mapbox token in order to successfully run `yarn build`, otherwise the build will fail due to failing to load the map images. You can get your own token [here](https://account.mapbox.com/access-tokens). Once you have a token, you should assign it to the `MAPBOX_ACCESS_TOKEN` environment variable.
 * Processed markdown can be found in `dist/chapters`
 * The `super-rentals` code can be found in `dist/code/super-rentals`
 


### PR DESCRIPTION
Without the token, the app won't build, so it's worth mentioning this in the README.