### PR TITLE
Fix stacktrace scrubbing

### DIFF
--- a/src/chapters/01-orientation.md
+++ b/src/chapters/01-orientation.md
@@ -60,7 +60,7 @@ del package.json
 ```
 
 ```run:file:patch hidden=true cwd=super-rentals filename=tests/index.html
-@@ -28,2 +28,81 @@
+@@ -28,2 +28,85 @@
      <script src="{{rootURL}}assets/tests.js"></script>
 +    <script>
 +      if (QUnit.urlParams.deterministic) {
@@ -116,7 +116,9 @@ del package.json
 +          details.runtime = clock.tick();
 +
 +          if (details.source) {
-+            details.source = details.source.replace(/.js((:[0-9]+):[0-9]+)/g, '.js');
++            Object.defineProperty(details, 'source', {
++              value: details.source.replace(/\.js((:[0-9]+)?:[0-9]+)/g, '.js')
++            });
 +          }
 +        });
 +
@@ -132,7 +134,9 @@ del package.json
 +          details.runtime = current;
 +
 +          if (details.source) {
-+            details.source = details.source.replace(/.js((:[0-9]+):[0-9]+)/g, '.js');
++            Object.defineProperty(details, 'source', {
++              value: details.source.replace(/\.js((:[0-9]+)?:[0-9]+)/g, '.js')
++            });
 +          }
 +        });
 +


### PR DESCRIPTION
The `stack` property was turned into a getter in [this QUnit commit](https://github.com/qunitjs/qunit/commit/5742024ba0c298bc0782d76d97b81db4c48a81cf).

This broke the stacktrace scrubbing which caused [a screenshot diff](https://github.com/ember-learn/guides-source/pull/1135):

<img width="1680" alt="Screen Shot 2019-10-11 at 11 28 36 AM" src="https://user-images.githubusercontent.com/55829/66641132-6cca1a80-ec1a-11e9-8906-d5c9084e92e4.png">

This commit fixed the issue by switching the assignment to use `Object.defineProperty` to overwrite QUnit's getter.