### PR TITLE
Try speeding up the build

### DIFF
--- a/src/chapters/03-automated-testing.md
+++ b/src/chapters/03-automated-testing.md
@@ -101,7 +101,7 @@ Finally, we asserted that clicking on the link should bring us to the `/about` U
 > Here, we are writing the tests in a framework called QUnit, which is where the functions `module`, `test` and `assert` come from. We also have additional helpers like `click`, `visit`, and `currentURL` provided by the `@ember/test-helpers` package. You can tell what comes from which package based on the `import` paths at the top of the file. Knowing this will be helpful when you need to search for documentation on the Internet or ask for help.
 
 ```run:command hidden=true cwd=super-rentals
-yarn test
+yarn test --path dist
 git add tests/acceptance/super-rentals-test.js
 ```
 
@@ -136,7 +136,7 @@ Don't forget to put that line back in when you are done!
 
 ```run:command hidden=true cwd=super-rentals
 git checkout app/templates/index.hbs
-yarn test
+yarn test --path dist
 ```
 
 ## Practicing the Testing Workflow
@@ -181,7 +181,7 @@ wait  #qunit-banner.qunit-pass
 ```
 
 ```run:command hidden=true cwd=super-rentals
-yarn test
+yarn test --path dist
 git add tests/acceptance/super-rentals-test.js
 ```
 

--- a/src/chapters/04-component-basics.md
+++ b/src/chapters/04-component-basics.md
@@ -118,7 +118,7 @@ Let's do the same for our other two pages as well.
 After saving, everything should look exactly the same as before, and all the tests should still pass. Very nice!
 
 ```run:command hidden=true cwd=super-rentals
-yarn test
+yarn test --path dist
 git add app/templates/index.hbs
 git add app/templates/about.hbs
 git add app/templates/contact.hbs
@@ -188,7 +188,7 @@ Instead of navigating to a URL, we start the test by rendering our `<Jumbo>` com
 Just like visit and click, which we used earlier, render is also an async step, so we need to pair it with the `await` keyword. Other than that, the rest of the test is very similar to the acceptance tests we wrote in the previous chapter. Make sure the test is passing by checking the tests UI in the browser.
 
 ```run:command hidden=true cwd=super-rentals
-yarn test
+yarn test --path dist
 git add tests/integration/components/jumbo-test.js
 ```
 
@@ -305,7 +305,7 @@ We updated the existing tests to assert that a `<nav>` element exists on each pa
 All tests should pass at this point!
 
 ```run:command hidden=true cwd=super-rentals
-yarn test
+yarn test --path dist
 git add tests/acceptance/super-rentals-test.js
 ```
 
@@ -357,7 +357,7 @@ The `{{outlet}}` keyword denotes the place where our site's pages should be rend
 This is much nicer! We can run our test suite, which confirms that everything still works after our refactor. We are ready to move on to the next feature!
 
 ```run:command hidden=true cwd=super-rentals
-yarn test
+yarn test --path dist
 git add app/templates/application.hbs
 git add app/templates/index.hbs
 git add app/templates/contact.hbs

--- a/src/chapters/05-more-about-components.md
+++ b/src/chapters/05-more-about-components.md
@@ -24,7 +24,7 @@ ember generate component rental
 The generator created two new files for us, a component template at `app/components/rental.hbs`, and a component test file at `tests/integration/components/rental-test.js`.
 
 ```run:command hidden=true cwd=super-rentals
-yarn test
+yarn test --path dist
 git add app/components/rental.hbs
 git add tests/integration/components/rental-test.js
 ```
@@ -90,7 +90,7 @@ Then, we will write a test to ensure all of the details are present. We will rep
 The test should pass.
 
 ```run:command hidden=true cwd=super-rentals
-yarn test
+yarn test --path dist
 git add app/components/rental.hbs
 git add tests/integration/components/rental-test.js
 ```
@@ -116,7 +116,7 @@ Finally, let's invoke this a couple of times from our index template to populate
 ```
 
 ```run:command hidden=true cwd=super-rentals
-yarn test
+yarn test --path dist
 git add app/templates/index.hbs
 ```
 
@@ -140,7 +140,7 @@ ember generate component rental/image
 This time, we had a `/` in the component's name. This resulted in the component being created at `app/components/rental/image.hbs`, which can be invoked as `<Rental::Image>`.
 
 ```run:command hidden=true cwd=super-rentals
-yarn test
+yarn test --path dist
 git add app/components/rental/image.hbs
 git add tests/integration/components/rental/image-test.js
 ```
@@ -232,7 +232,7 @@ Finally, we should also update the tests for the `<Rental>` component to confirm
 Because we already tested `<Rental::Image>` extensively on its own, we can omit the details here and keep our assertion to the bare minimum. That way, we won't  _also_ have to update the `<Rental>` tests whenever we make changes to `<Rental::Image>`.
 
 ```run:command hidden=true cwd=super-rentals
-yarn test
+yarn test --path dist
 git add app/components/rental.hbs
 git add app/components/rental/image.hbs
 git add tests/integration/components/rental-test.js

--- a/src/chapters/06-interactive-components.md
+++ b/src/chapters/06-interactive-components.md
@@ -37,7 +37,7 @@ ember generate component-class rental/image
 ```
 
 ```run:command hidden=true cwd=super-rentals
-yarn test
+yarn test --path dist
 git add app/components/rental/image.js
 ```
 
@@ -88,7 +88,7 @@ Let's update our template to use this state we just added:
 In the template, we have access to the component's instance variables. The `{{#if ...}}...{{else}}...{{/if}}` *[conditionals][TODO: link to conditionals]* syntax allows us to render different content based on a condition (in this case, the value of the instance variable `this.isLarge`). Combining these two features, we can render either the small or the large version of the image accordingly.
 
 ```run:command hidden=true cwd=super-rentals
-yarn test
+yarn test --path dist
 git add app/components/rental/image.hbs
 git add app/components/rental/image.js
 ```
@@ -130,7 +130,7 @@ Since this pattern of initializing instance variables in the constructor is pret
 This does exactly the same thing as before, but it's much shorter and less to type!
 
 ```run:command hidden=true cwd=super-rentals
-yarn test
+yarn test --path dist
 git add app/components/rental/image.js
 ```
 
@@ -220,7 +220,7 @@ wait  .rentals li:first-of-type article.rental .image.large img
 ```
 
 ```run:command hidden=true cwd=super-rentals
-yarn test
+yarn test --path dist
 git add app/components/rental/image.hbs
 git add app/components/rental/image.js
 ```
@@ -265,7 +265,7 @@ Finally, let's write a test for this new behavior:
 ```
 
 ```run:command hidden=true cwd=super-rentals
-yarn test
+yarn test --path dist
 git add tests/integration/components/rental/image-test.js
 ```
 
@@ -305,7 +305,7 @@ These changes are buried deep within the large amount of duplicated code. We can
 The expression version of `{{if}}` takes two arguments. The first argument is the *[condition][TODO: link to condition]*. The second argument is the expression that should be evaluated if the condition is true.
 
 ```run:command hidden=true cwd=super-rentals
-yarn test
+yarn test --path dist
 git add app/components/rental/image.hbs
 ```
 
@@ -328,7 +328,7 @@ Whether or not this is an improvement in the clarity of our code is mostly a mat
 Run the test suite one last time to confirm our refactor didn't break anything unexpectedly, and we will be ready for the next challenge!
 
 ```run:command hidden=true cwd=super-rentals
-yarn test
+yarn test --path dist
 git add app/components/rental/image.hbs
 ```
 

--- a/src/chapters/07-reusable-components.md
+++ b/src/chapters/07-reusable-components.md
@@ -90,7 +90,7 @@ However, in the case of our `<Map>` component, we are pretty sure that we are go
 > Too much typing? Use `ember g component map -gc` instead. The `-gc` flag stands for **G**limmer **c**omponent, but you may also remember it as **g**enerate **c**lass.
 
 ```run:command hidden=true cwd=super-rentals
-yarn test
+yarn test --path dist
 git add app/components/map.hbs
 git add app/components/map.js
 git add tests/integration/components/map-test.js
@@ -241,7 +241,7 @@ Note that the `hasAttribute` test helper from [`qunit-dom`][TODO: link to qunit-
 *Fingers crossed...* Let's run our tests.
 
 ```run:command hidden=true cwd=super-rentals
-yarn test
+yarn test --path dist
 git add app/components/map.hbs
 git add app/components/map.js
 git add tests/integration/components/map-test.js
@@ -291,7 +291,7 @@ For good measure, we will also add an assertion to the `<Rental>` tests to make 
 ```
 
 ```run:command hidden=true cwd=super-rentals
-yarn test
+yarn test --path dist
 git add app/components/rental.hbs
 git add tests/integration/components/rental-test.js
 ```
@@ -340,7 +340,7 @@ index 78e765f..1cad468 100644
 Much nicer! And all of our tests still pass!
 
 ```run:command hidden=true cwd=super-rentals
-yarn test
+yarn test --path dist
 git add app/components/map.hbs
 git add app/components/map.js
 ```
@@ -415,7 +415,7 @@ Instead, `this` refers to a special *[test context][TODO: link to test context]*
 With all our tests passing, we are ready to move on!
 
 ```run:command hidden=true cwd=super-rentals
-yarn test
+yarn test --path dist
 git add tests/integration/components/map-test.js
 ```
 

--- a/src/chapters/08-working-with-data.md
+++ b/src/chapters/08-working-with-data.md
@@ -87,7 +87,7 @@ wait  .rentals li:nth-of-type(3) article.rental
 Awesome!
 
 ```run:command hidden=true cwd=super-rentals
-yarn test
+yarn test --path dist
 git add app/routes/index.js
 git add app/templates/index.hbs
 ```
@@ -201,7 +201,7 @@ Therefore, in our `<Rental>` component's test, we will have to feed the data int
 Notice that we also need to update the invocation of the `<Rental>` component in the `render` function call to also have a `@rental` argument passed into it. If we run our tests now, they should all pass!
 
 ```run:command hidden=true cwd=super-rentals
-yarn test
+yarn test --path dist
 git add app/components/rental.hbs
 git add app/templates/index.hbs
 git add tests/integration/components/rental-test.js
@@ -376,7 +376,7 @@ Hooray! Finally we're seeing different rental properties in our list. And we got
 Better yet, all of our tests are still passing too!
 
 ```run:command hidden=true cwd=super-rentals
-yarn test
+yarn test --path dist
 git add app/routes/index.js
 git add app/templates/index.hbs
 ```


### PR DESCRIPTION
It seems like we are slowing running up against the Travis build time limit, and with the part 2 work, we may have *just* crossed the line.

I think a lot of time is spent running `yarn test`, which has to first run a build (`ember build`) before it running the tests.

Since we already have the development server running in the and already rebuilding the app whenever we make changes, it may be faster if we just try to reuse the build in the tests.