### PR TITLE
Make screenshot less flaky

### DIFF
--- a/src/chapters/12-service-injection.md
+++ b/src/chapters/12-service-injection.md
@@ -149,7 +149,7 @@ visit http://localhost:4200/rentals/grand-old-mansion
 wait  .share.button
 # Remove the target attribute so that clicking on the button doesn't open a new page.
 eval  document.querySelector(".share.button").removeAttribute('target')
-click .share.button
+click .share.button, true
 wait  textarea#status
 ```
 

--- a/src/lib/plugins/run-code-blocks/directives/screenshot.ts
+++ b/src/lib/plugins/run-code-blocks/directives/screenshot.ts
@@ -72,11 +72,18 @@ async function main() {
     }
 
     let [action, ...rest] = step.split(/(\s+)/);
-    let params = rest.join('').split(/,\s*/);
+    let params = rest.join('').trimStart().split(/,\s*/);
 
     switch (action) {
       case 'click':
-        script.push(`  await page.click(${js(params[0])});`);
+        if (params[1] === 'true') {
+          script.push(`  await Promise.all([`);
+          script.push(`    page.waitForNavigation({ waitUtil: 'networkidle0' }),`);
+          script.push(`    page.click(${js(params[0])})`);
+          script.push(`  ]);`);
+        } else {
+          script.push(`  await page.click(${js(params[0])});`);
+        }
         break;
       case 'type':
         script.push(`  await page.type(${js(params[0])}, ${js(params[1])});`);


### PR DESCRIPTION
Add a second parameter to the `click` screenshot DSL to denote "external" links that performs a navigation. This will wait for the navigation to complete before moving on to the next step and hopefully alleviate some of the build failures we are seeing with puppeteer reporting "Cannot take screenshot with 0 width".