### PR TITLE
Fix: Automated Test Line 174

### DIFF
--- a/src/markdown/tutorial/part-1/03-automated-testing.md
+++ b/src/markdown/tutorial/part-1/03-automated-testing.md
@@ -167,7 +167,7 @@ Let's practice what we learned by adding tests for the remaining pages:
 +    assert.equal(currentURL(), '/getting-in-touch');
 +    assert.dom('h2').hasText('Contact Us');
 +
-+    assert.dom('a.button').hasText('About');
++    assert.dom('a.button').hasText('About Us');
 +    await click('.jumbo a.button');
 +
 +    assert.equal(currentURL(), '/about');


### PR DESCRIPTION
Minor fix for failing acceptance test in the Octane guides.

This PR updates line 174 of the acceptance test file to fix the failing test.
This changes `assert.dom('a.button').hasText('About');` to `assert.dom('a.button').hasText('About Us');`