### PR TITLE
A number of copy fixes found in the release (Octane) guides

### DIFF
--- a/src/markdown/tutorial/part-1/08-working-with-data.md
+++ b/src/markdown/tutorial/part-1/08-working-with-data.md
@@ -292,7 +292,7 @@ git add app/routes/index.js
 
 ## Adapting Server Data
 
-Before we go any further, let's pause for a second to look at the our server's data again.
+Before we go any further, let's pause for a second to look at the server's data again.
 
 ```run:file:show lang=json cwd=super-rentals filename=public/api/rentals.json
 ```

--- a/src/markdown/tutorial/part-2/11-ember-data.md
+++ b/src/markdown/tutorial/part-2/11-ember-data.md
@@ -105,7 +105,7 @@ git add tests/unit/models/rental-test.js
 >
 > We could also have used the `ember generate model rental` command in the first place, which would have created both the model and test file for us.
 
-The generator created some boilerplate code for us, which servers as a pretty good starting point for writing our test:
+The generator created some boilerplate code for us, which serves as a pretty good starting point for writing our test:
 
 ```run:file:patch lang=js cwd=super-rentals filename=tests/unit/models/rental-test.js
 @@ -6,7 +6,32 @@


### PR DESCRIPTION
- Typo in src/markdown/tutorial/part-2/11-ember-data.md
    per https://github.com/ember-learn/guides-source/pull/1248#issuecomment-570293720
- Typo in src/markdown/tutorial/part-1/08-working-with-data.md
    per https://github.com/ember-learn/guides-source/pull/1242#issuecomment-570299826