### PR TITLE
fix: Rental::Image test uses correct asset location

### DIFF
--- a/src/markdown/tutorial/part-1/06-interactive-components.md
+++ b/src/markdown/tutorial/part-1/06-interactive-components.md
@@ -243,7 +243,7 @@ Finally, let's write a test for this new behavior:
 +  test('clicking on the component toggles its size', async function(assert) {
 +    await render(hbs`
 +      <Rental::Image
-+        src="/assets/teaching-tomster.png"
++        src="/assets/images/teaching-tomster.png"
 +        alt="Teaching Tomster"
 +      />
 +    `);


### PR DESCRIPTION
Sometimes I'm not able to reproduce this issue in Ubuntu 20 on Firefox. 

What happens is that the tutorial places the Tomster image in `assets/images/` but the `Rental::Image` test passes in to `src` -> `asset/teaching-tomster.png`. It throws an error along the lines that it's not able to find the image.