### PR TITLE
Added missing .jumbo class for consistency's sake

### DIFF
--- a/src/markdown/tutorial/part-1/03-automated-testing.md
+++ b/src/markdown/tutorial/part-1/03-automated-testing.md
@@ -167,7 +167,7 @@ Let's practice what we learned by adding tests for the remaining pages:
 +    assert.equal(currentURL(), '/getting-in-touch');
 +    assert.dom('h2').hasText('Contact Us');
 +
-+    assert.dom('a.button').hasText('About');
++    assert.dom('.jumbo a.button').hasText('About');
 +    await click('.jumbo a.button');
 +
 +    assert.equal(currentURL(), '/about');


### PR DESCRIPTION
In all the other assertions for the other pages, we also use the ´.jumbo´ class. While I understand this still works correctly for the tests in the tutorial, I feel like it is unnecessarily confusing for beginners (especially when it's not called out in the text after the example either).