### PR TITLE
Add code markup to Input component reference

### DIFF
--- a/src/markdown/tutorial/part-2/12-provider-components.md
+++ b/src/markdown/tutorial/part-2/12-provider-components.md
@@ -220,7 +220,7 @@ Next, we'll wire up our query state in the component template.
    </label>
 ```
 
-Interesting! There are a few things happening in this one-line template change. First, we're moving from using a plain HTML `<input>` tag to using an `<Input>` tag instead! As it turns out, Ember provides us with a helpful little *[<Input> component][TODO: link to input component]* for this exact use case. The `<Input>` component is actually just a wrapper around the `<input>` element.
+Interesting! There are a few things happening in this one-line template change. First, we're moving from using a plain HTML `<input>` tag to using an `<Input>` tag instead! As it turns out, Ember provides us with a helpful little *[`<Input>` component][TODO: link to input component]* for this exact use case. The `<Input>` component is actually just a wrapper around the `<input>` element.
 
 Ember's `<Input>` component is pretty neat; it will wire up things behind the scenes such that, whenever the user types something into the input box, `this.query` changes accordingly. In other words, `this.query` is kept in sync with the value of what is being searched; we finally have the perfect way of storing the state of our search query!
 


### PR DESCRIPTION
[Guide](https://guides.emberjs.com/release/tutorial/part-2/provider-components/#toc_using-embers-input) is currently rendering this Input reference as an actual `<input>` element:

<img width="766" alt="Screen Shot 2020-10-07 at 10 34 29 AM" src="https://user-images.githubusercontent.com/421496/95345501-c8a89d00-0888-11eb-9ff7-0940d02b730d.png">