### PR TITLE
Upgraded webfactory/ssh-agent action to v0.4.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,7 @@ jobs:
           git config --global user.name "Tomster"
           git config --global user.email "tomster@emberjs.com"
       - name: Set up SSH
-        uses: webfactory/ssh-agent@v0.1.1
+        uses: webfactory/ssh-agent@v0.4.1
         with:
           ssh-private-key: ${{ secrets.GUIDES_SOURCE_DEPLOY_KEY }}
       - name: Install dependencies
@@ -300,7 +300,7 @@ jobs:
           git config --global user.name "Tomster"
           git config --global user.email "tomster@emberjs.com"
       - name: Set up SSH
-        uses: webfactory/ssh-agent@v0.1.1
+        uses: webfactory/ssh-agent@v0.4.1
         with:
           ssh-private-key: ${{ secrets.SUPER_RENTALS_DEPLOY_KEY }}
       - name: Download artifacts
@@ -359,7 +359,7 @@ jobs:
           git config --global user.name "Tomster"
           git config --global user.email "tomster@emberjs.com"
       - name: Set up SSH
-        uses: webfactory/ssh-agent@v0.1.1
+        uses: webfactory/ssh-agent@v0.4.1
         with:
           ssh-private-key: ${{ secrets.SUPER_RENTALS_DEPLOY_KEY }}
       - name: Download artifacts


### PR DESCRIPTION
## Description

Since November 16, the `set-env` command has been disabled in GitHub Actions for security reasons. I noticed the scheduled `build` workflow has been failing over the past few days.

Upgrading `webfactory/ssh-agent` action to the latest version, `v0.4.1`, should fix the issue.


## References

- https://github.com/webfactory/ssh-agent/releases/tag/v0.4.1