### PR TITLE
Fix JS snippet syntax highlighting

### DIFF
--- a/src/markdown/tutorial/part-2/10-service-injection.md
+++ b/src/markdown/tutorial/part-2/10-service-injection.md
@@ -185,7 +185,7 @@ git add tests/acceptance/super-rentals-test.js
 
 To be sure, let's add some tests! Let's start with an acceptance test:
 
-```run:file:patch lang=handlebars cwd=super-rentals filename=tests/acceptance/super-rentals-test.js
+```run:file:patch lang=js cwd=super-rentals filename=tests/acceptance/super-rentals-test.js
 @@ -1,3 +1,3 @@
  import { module, test } from 'qunit';
 -import { click, visit, currentURL } from '@ember/test-helpers';


### PR DESCRIPTION
In [this section of the Service Injection page](https://guides.emberjs.com/release/tutorial/part-2/service-injection/#toc_why-we-cant-test-windowlocationhref), the code snippet for the `super-rentals-test.js` file lacks syntax highlighting because the snippet language was set to Handlebars when it should be JavaScript:

<img width="755" alt="Screen Shot 2021-02-14 at 3 29 28 AM" src="https://user-images.githubusercontent.com/588690/107874171-e9a37f00-6e74-11eb-9c69-9ecdd2ff0331.png">