### PR TITLE
Updated default branch name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on:
   pull_request: {}
   push:
     branches:
-      - master
+      - main
   schedule:
     - cron: '0 0 * * *'
 
@@ -126,7 +126,7 @@ jobs:
     name: Deploy to ember-learn/guides-source (super-rentals-tutorial branch)
     needs: build
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Set up Git
         run: |
@@ -156,7 +156,7 @@ jobs:
           IFS=$'\n\t'
 
           if ! git clone git@github.com:ember-learn/guides-source --depth 1 -b super-rentals-tutorial; then
-            git clone git@github.com:ember-learn/guides-source --depth 1 -b master
+            git clone git@github.com:ember-learn/guides-source --depth 1 -b main
             cd guides-source
             git checkout -b super-rentals-tutorial
           fi
@@ -293,7 +293,7 @@ jobs:
     name: Deploy to ember-learn/super-rentals (super-rentals-tutorial-output branch)
     needs: build
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Set up Git
         run: |
@@ -336,23 +336,23 @@ jobs:
       - name: Push
         run: |
           git remote add super-rentals git@github.com:ember-learn/super-rentals.git
-          git push -f super-rentals master:super-rentals-tutorial-output
+          git push -f super-rentals main:super-rentals-tutorial-output
 
   deploy-code-flattened:
-    # This job deploys the built app to the master branch of the
+    # This job deploys the built app to the main branch of the
     # ember-learn/super-rentals repository. This branch does not preserve
     # the commit history of the tutorial flow. Instead, it squashes the changes
-    # into a single commit on the master branch. This preserves
+    # into a single commit on the main branch. This preserves
     # a linear history of changes to the built app over time, either due to
     # changes to the generator blueprints, or changes to the tutorial content
     # itself (e.g. refactoring to use new ember features). A lot of times, the
     # built app's source code remains stable and so there may be no changes to
     # push here.
     #
-    name: Deploy to ember-learn/super-rentals (master branch)
+    name: Deploy to ember-learn/super-rentals (main branch)
     needs: build
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Set up Git
         run: |
@@ -397,7 +397,7 @@ jobs:
           git commit --allow-empty -m "$COMMIT_MESSAGE"
           git remote add output ../output
           git fetch output
-          git merge --squash --no-commit --allow-unrelated-histories output/master
+          git merge --squash --no-commit --allow-unrelated-histories output/main
           git reset HEAD~ -- README.md app.json
           git commit --allow-empty --amend --no-edit
         env:
@@ -408,7 +408,7 @@ jobs:
           set -euo pipefail
           IFS=$'\n\t'
 
-          if git diff --exit-code origin/master; then
+          if git diff --exit-code origin/main; then
             echo "Nothing to push"
           else
             git push

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,8 +171,8 @@ Correctly spelled words flagged as misspelt can be added to the local dictionary
 
 Finally, the tutorial will be linted using the `guides` markdown linter when the PR is created.  Since the linter will use the `guides` dictionary the words in `.local.dic` must also be in the guides `.local.dic` file for linting to pass.
 
-When new words are added to the local dictionary, a separate PR must be opened on the guides to add them to the guides dictionary. If there are words that you think belong in the master Ember [dictionary](https://github.com/maxwondercorn/ember-dictionary) versus being in the local dictionary, open a PR.
+When new words are added to the local dictionary, a separate PR must be opened on the guides to add them to the guides dictionary. If there are words that you think belong to the [Ember dictionary](https://github.com/maxwondercorn/ember-dictionary), please open a PR in that repo.
 
 #### Pull Request Merging
 
-After the pull request is merged into the master branch, the generated markdown and code output will be pushed to a branch on the markdown/code output will be pushed to a branch on the [guides](https://github.com/ember-learn/guides-source) and [super rentals repos](https://github.com/ember-learn/guides-source/tree/super-rentals-tutorial) so that they can be further reviewed by their maintainers before integrating into the tutorial code/app and markdown.
+After the pull request is merged to the `main` branch, the generated markdown and code output will be pushed to a branch on the markdown/code output will be pushed to a branch on the [guides](https://github.com/ember-learn/guides-source) and [super rentals repos](https://github.com/ember-learn/guides-source/tree/super-rentals-tutorial) so that they can be further reviewed by their maintainers before integrating into the tutorial code/app and markdown.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Runnable super-rentals tutorial
 
-[![Build Status](https://github.com/ember-learn/super-rentals-tutorial/workflows/Build/badge.svg?branch=master)](https://github.com/ember-learn/super-rentals-tutorial/actions?query=workflow%3ABuild+branch%3Amaster)
+[![Build Status](https://github.com/ember-learn/super-rentals-tutorial/actions/workflows/build.yml/badge.svg)](https://github.com/ember-learn/super-rentals-tutorial/actions/workflows/build.yml)
 
 ## What?
 
@@ -468,7 +468,7 @@ Example:
 
     ```run:ignore:command cwd=super-rentals
     # FIXME: don't run this for now, since Heroku is down atm
-    git push heroku master
+    git push heroku main
     ```
 
 ### `run:pause`


### PR DESCRIPTION
## Description

In `super-rentals-tutorial` and `super-rentals`, I used GitHub's `Rename default branch` feature to rename the default branch to `main`. This feature automatically updates the destination branch for any open pull requests.

<img width="400" alt="Screenshot 2021-04-06 at 07 45 20" src="https://user-images.githubusercontent.com/16869656/113664391-f5a90180-96ab-11eb-82f4-7f001968181f.png">

On Heroku and Netlify, I updated the branch to `main` (for `super-rentals`) as well:

<img width="1440" alt="Screenshot 2021-04-06 at 07 54 40" src="https://user-images.githubusercontent.com/16869656/113665148-40774900-96ad-11eb-8648-3b95892f5c03.png">

<img width="640" alt="Screenshot 2021-04-06 at 07 55 24" src="https://user-images.githubusercontent.com/16869656/113665189-571da000-96ad-11eb-9eca-e7b11532c10e.png">
