### PR TITLE
Replace broken image, closes #182

### DIFF
--- a/src/assets/downloads/data/api/rentals.json
+++ b/src/assets/downloads/data/api/rentals.json
@@ -30,7 +30,7 @@
         },
         "category": "Condo",
         "bedrooms": 1,
-        "image": "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        "image": "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         "description": "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/src/assets/downloads/data/api/rentals/urban-living.json
+++ b/src/assets/downloads/data/api/rentals/urban-living.json
@@ -12,7 +12,7 @@
       },
       "category": "Condo",
       "bedrooms": 1,
-      "image": "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+      "image": "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
       "description": "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
     }
   }

--- a/src/markdown/tutorial/part-2/12-provider-components.md
+++ b/src/markdown/tutorial/part-2/12-provider-components.md
@@ -154,7 +154,7 @@ module('Integration | Component | rentals', function (hooks) {
           type: 'Community',
           bedrooms: 1,
           image:
-            'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+            'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
           description:
             'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.',
         },


### PR DESCRIPTION
The previous image is no longer available on wiki commons. This new image of a building in Seattle. More info about it is here: https://commons.wikimedia.org/wiki/File:Seattle_-_Barnes_and_Bell_Buildings.jpg

The broken image blocks the app building steps that publish to the Ember Guides and to the example app.