### PR TITLE
Update the display text to match expectations

### DIFF
--- a/src/markdown/tutorial/part-1/01-orientation.md
+++ b/src/markdown/tutorial/part-1/01-orientation.md
@@ -46,7 +46,7 @@ Hack: make an empty package.json to convince ember-cli we are really not in an E
 # pretend we are running NPM.
 
 #[cfg(all(ci, unix))]
-#[display(ember new super-rentals)]
+#[display(ember new super-rentals --lang en)]
 ember new super-rentals --lang en --yarn \
   | awk '{ gsub("Yarn", "npm"); gsub("yarn", "npm"); print }'
 


### PR DESCRIPTION
The tutorial text states that the `--lang en` option will be passed but the generated example doesn't show that.

I am not able to test the execution of this change, but as it's effectively a typo change I hope you will be able to make use of the request.