### PR TITLE
Use ember-data@4.1.0-alpha while waiting for backport

### DIFF
--- a/src/markdown/tutorial/part-1/01-orientation.md
+++ b/src/markdown/tutorial/part-1/01-orientation.md
@@ -192,6 +192,19 @@ del package.json
 
 ```
 
+<!-- BEGIN patch: waiting for https://github.com/emberjs/data/pull/7667 backport -->
+
+```run:command hidden=true cwd=super-rentals
+#[cfg(unix)]
+if $(ember --version | grep "ember-cli: 4.0.0"); then
+  yarn upgrade ember-data@~4.1.0-alpha.10;
+  git add package.json;
+  git add yarn.lock;
+fi
+```
+
+<!-- END patch: waiting for https://github.com/emberjs/data/pull/7667 backport -->
+
 ```run:command hidden=true cwd=super-rentals
 yarn test
 git add app/index.html


### PR DESCRIPTION
https://github.com/emberjs/data/pull/7667

This is currently causing the build to fail since without this patch it triggers the ember implicit injection deprecation.