### PR TITLE
Update tutorial to use `assert.strictEqual` in place of `assert.equal` to pass eslint-plugin-qunit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         channel:
-          - release
+          # - release TODO: Re-enable once 4.0 is released
           - beta
     steps:
       - name: Set up Git

--- a/src/markdown/tutorial/part-1/03-automated-testing.md
+++ b/src/markdown/tutorial/part-1/03-automated-testing.md
@@ -68,17 +68,17 @@ Let's open the generated test file and replace the boilerplate test with our own
 -  test('visiting /super-rentals', async function (assert) {
 -    await visit('/super-rentals');
 -
--    assert.equal(currentURL(), '/super-rentals');
+-    assert.strictEqual(currentURL(), '/super-rentals');
 +  test('visiting /', async function (assert) {
 +    await visit('/');
 +
-+    assert.equal(currentURL(), '/');
++    assert.strictEqual(currentURL(), '/');
 +    assert.dom('h2').hasText('Welcome to Super Rentals!');
 +
 +    assert.dom('.jumbo a.button').hasText('About Us');
 +    await click('.jumbo a.button');
 +
-+    assert.equal(currentURL(), '/about');
++    assert.strictEqual(currentURL(), '/about');
    });
 ```
 
@@ -152,25 +152,25 @@ Let's practice what we learned by adding tests for the remaining pages:
 +  test('visiting /about', async function (assert) {
 +    await visit('/about');
 +
-+    assert.equal(currentURL(), '/about');
++    assert.strictEqual(currentURL(), '/about');
 +    assert.dom('h2').hasText('About Super Rentals');
 +
 +    assert.dom('.jumbo a.button').hasText('Contact Us');
 +    await click('.jumbo a.button');
 +
-+    assert.equal(currentURL(), '/getting-in-touch');
++    assert.strictEqual(currentURL(), '/getting-in-touch');
 +  });
 +
 +  test('visiting /getting-in-touch', async function (assert) {
 +    await visit('/getting-in-touch');
 +
-+    assert.equal(currentURL(), '/getting-in-touch');
++    assert.strictEqual(currentURL(), '/getting-in-touch');
 +    assert.dom('h2').hasText('Contact Us');
 +
 +    assert.dom('.jumbo a.button').hasText('About');
 +    await click('.jumbo a.button');
 +
-+    assert.equal(currentURL(), '/about');
++    assert.strictEqual(currentURL(), '/about');
 +  });
  });
 ```

--- a/src/markdown/tutorial/part-1/04-component-basics.md
+++ b/src/markdown/tutorial/part-1/04-component-basics.md
@@ -265,17 +265,17 @@ But what kind of test? We *could* write a component test for the `<NavBar>` by i
 
 ```run:file:patch lang=js cwd=super-rentals filename=tests/acceptance/super-rentals-test.js
 @@ -11,2 +11,4 @@
-     assert.equal(currentURL(), '/');
+     assert.strictEqual(currentURL(), '/');
 +    assert.dom('nav').exists();
 +    assert.dom('h1').hasText('SuperRentals');
      assert.dom('h2').hasText('Welcome to Super Rentals!');
 @@ -23,2 +25,4 @@
-     assert.equal(currentURL(), '/about');
+     assert.strictEqual(currentURL(), '/about');
 +    assert.dom('nav').exists();
 +    assert.dom('h1').hasText('SuperRentals');
      assert.dom('h2').hasText('About Super Rentals');
 @@ -35,2 +39,4 @@
-     assert.equal(currentURL(), '/getting-in-touch');
+     assert.strictEqual(currentURL(), '/getting-in-touch');
 +    assert.dom('nav').exists();
 +    assert.dom('h1').hasText('SuperRentals');
      assert.dom('h2').hasText('Contact Us');
@@ -291,13 +291,13 @@ But what kind of test? We *could* write a component test for the `<NavBar>` by i
 +    assert.dom('nav a.menu-contact').hasText('Contact');
 +
 +    await click('nav a.menu-about');
-+    assert.equal(currentURL(), '/about');
++    assert.strictEqual(currentURL(), '/about');
 +
 +    await click('nav a.menu-contact');
-+    assert.equal(currentURL(), '/getting-in-touch');
++    assert.strictEqual(currentURL(), '/getting-in-touch');
 +
 +    await click('nav a.menu-index');
-+    assert.equal(currentURL(), '/');
++    assert.strictEqual(currentURL(), '/');
 +  });
  });
 ```

--- a/src/markdown/tutorial/part-2/09-route-params.md
+++ b/src/markdown/tutorial/part-2/09-route-params.md
@@ -333,13 +333,13 @@ Finally, let's add a `rental` template to actually *invoke* our `<Rental::Detail
 +    assert.dom('.rental').exists({ count: 3 });
 +
 +    await click('.rental:first-of-type a');
-+    assert.equal(currentURL(), '/rentals/grand-old-mansion');
++    assert.strictEqual(currentURL(), '/rentals/grand-old-mansion');
 +  });
 +
 +  test('visiting /rentals/grand-old-mansion', async function (assert) {
 +    await visit('/rentals/grand-old-mansion');
 +
-+    assert.equal(currentURL(), '/rentals/grand-old-mansion');
++    assert.strictEqual(currentURL(), '/rentals/grand-old-mansion');
 +    assert.dom('nav').exists();
 +    assert.dom('h1').containsText('SuperRentals');
 +    assert.dom('h2').containsText('Grand Old Mansion');

--- a/src/markdown/tutorial/part-2/10-service-injection.md
+++ b/src/markdown/tutorial/part-2/10-service-injection.md
@@ -262,39 +262,39 @@ We will take advantage of this capability in our component test:
  import { setupRenderingTest } from 'ember-qunit';
 +import Service from '@ember/service';
  import { render } from '@ember/test-helpers';
-@@ -5,21 +6,31 @@ import { hbs } from 'ember-cli-htmlbars';
+@@ -5,2 +6,10 @@
 
--module('Integration | Component | share-button', function (hooks) {
--  setupRenderingTest(hooks);
 +const MOCK_URL = new URL('/foo/bar?baz=true#some-section', window.location.origin);
-
--  test('it renders', async function (assert) {
--    // Set any properties with this.set('myProperty', 'value');
--    // Handle any actions with this.set('myAction', function(val) { ... });
++
 +class MockRouterService extends Service {
 +  get currentURL() {
 +    return '/foo/bar?baz=true#some-section';
 +  }
 +}
++
+ module('Integration | Component | share-button', function (hooks) {
+@@ -8,18 +17,20 @@
 
--    await render(hbs`<ShareButton />`);
-+module('Integration | Component | share-button', function (hooks) {
-+  setupRenderingTest(hooks);
-
--    assert.dom(this.element).hasText('');
+-  test('it renders', async function (assert) {
+-    // Set any properties with this.set('myProperty', 'value');
+-    // Handle any actions with this.set('myAction', function(val) { ... });
 +  hooks.beforeEach(function () {
 +    this.owner.register('service:router', MockRouterService);
 +  });
 
+-    await render(hbs`<ShareButton />`);
++  test('basic usage', async function (assert) {
++    await render(hbs`<ShareButton>Tweet this!</ShareButton>`);
+
+-    assert.dom(this.element).hasText('');
+-
 -    // Template block usage:
 -    await render(hbs`
 -      <ShareButton>
 -        template block text
 -      </ShareButton>
 -    `);
-+  test('basic usage', async function (assert) {
-+    await render(hbs`<ShareButton>Tweet this!</ShareButton>`);
-
+-
 -    assert.dom(this.element).hasText('template block text');
 +    assert
 +      .dom('a')

--- a/src/markdown/tutorial/part-2/10-service-injection.md
+++ b/src/markdown/tutorial/part-2/10-service-injection.md
@@ -174,9 +174,9 @@ To be sure, let's add some tests! Let's start with an acceptance test:
 +    let button = find('.share.button');
 +
 +    let tweetURL = new URL(button.href);
-+    assert.equal(tweetURL.host, 'twitter.com');
++    assert.strictEqual(tweetURL.host, 'twitter.com');
 +
-+    assert.equal(
++    assert.strictEqual(
 +      tweetURL.searchParams.get('url'),
 +      `${window.location.origin}/rentals/grand-old-mansion`
 +    );
@@ -202,7 +202,7 @@ wait  #qunit-banner.qunit-fail
 
 Looking at the failure closely, the problem seems to be that the component had captured `http://localhost:4200/tests` as the "current page's URL". The issue here is that the `<ShareButton>` component uses `window.location.href` to capture the current URL. Because we are running our tests at `http://localhost:4200/tests`, that's what we got. *Technically* it's not wrong, but this is certainly not what we meant. Gotta love computers!
 
-This brings up an interesting question – why does the `currentURL()` test helper not have the same problem? In our test, we have been writing assertions like `assert.equal(currentURL(), '/about');`, and those assertions did not fail.
+This brings up an interesting question – why does the `currentURL()` test helper not have the same problem? In our test, we have been writing assertions like `assert.strictEqual(currentURL(), '/about');`, and those assertions did not fail.
 
 It turns out that this is something Ember's router handled for us. In an Ember app, the router is responsible for handling navigation and maintaining the URL. For example, when you click on a `<LinkTo>` component, it will ask the router to execute a *[route transition](../../../routing/preventing-and-retrying-transitions/)*. Normally, the router is set up to update the browser's address bar whenever it transitions into a new route. That way, your users will be able to use the browser's back button and bookmark functionality just like any other webpage.
 
@@ -351,7 +351,7 @@ While we are here, let's add some more tests for the various functionalities of 
 @@ -35,2 +36,53 @@
        .containsText('Tweet this!');
 +
-+    assert.equal(
++    assert.strictEqual(
 +      this.tweetParam('url'),
 +      new URL('/foo/bar?baz=true#some-section', window.location.origin)
 +    );
@@ -362,7 +362,7 @@ While we are here, let's add some more tests for the various functionalities of 
 +      hbs`<ShareButton @text="Hello Twitter!">Tweet this!</ShareButton>`
 +    );
 +
-+    assert.equal(this.tweetParam('text'), 'Hello Twitter!');
++    assert.strictEqual(this.tweetParam('text'), 'Hello Twitter!');
 +  });
 +
 +  test('it supports passing @hashtags', async function (assert) {
@@ -370,12 +370,12 @@ While we are here, let's add some more tests for the various functionalities of 
 +      hbs`<ShareButton @hashtags="foo,bar,baz">Tweet this!</ShareButton>`
 +    );
 +
-+    assert.equal(this.tweetParam('hashtags'), 'foo,bar,baz');
++    assert.strictEqual(this.tweetParam('hashtags'), 'foo,bar,baz');
 +  });
 +
 +  test('it supports passing @via', async function (assert) {
 +    await render(hbs`<ShareButton @via="emberjs">Tweet this!</ShareButton>`);
-+    assert.equal(this.tweetParam('via'), 'emberjs');
++    assert.strictEqual(this.tweetParam('via'), 'emberjs');
 +  });
 +
 +  test('it supports adding extra classes', async function (assert) {

--- a/src/markdown/tutorial/part-2/10-service-injection.md
+++ b/src/markdown/tutorial/part-2/10-service-injection.md
@@ -278,23 +278,23 @@ We will take advantage of this capability in our component test:
 -  test('it renders', async function (assert) {
 -    // Set any properties with this.set('myProperty', 'value');
 -    // Handle any actions with this.set('myAction', function(val) { ... });
+-
+-    await render(hbs`<ShareButton />`);
+-
+-    assert.dom(this.element).hasText('');
 +  hooks.beforeEach(function () {
 +    this.owner.register('service:router', MockRouterService);
 +  });
 
--    await render(hbs`<ShareButton />`);
-+  test('basic usage', async function (assert) {
-+    await render(hbs`<ShareButton>Tweet this!</ShareButton>`);
-
--    assert.dom(this.element).hasText('');
--
 -    // Template block usage:
 -    await render(hbs`
 -      <ShareButton>
 -        template block text
 -      </ShareButton>
 -    `);
--
++  test('basic usage', async function (assert) {
++    await render(hbs`<ShareButton>Tweet this!</ShareButton>`);
+
 -    assert.dom(this.element).hasText('template block text');
 +    assert
 +      .dom('a')

--- a/src/markdown/tutorial/part-2/10-service-injection.md
+++ b/src/markdown/tutorial/part-2/10-service-injection.md
@@ -352,7 +352,7 @@ While we are here, let's add some more tests for the various functionalities of 
 @@ -38,2 +41,50 @@
        .containsText('Tweet this!');
 +
-+      assert.strictEqual(this.tweetParam('url'), MOCK_URL.href);
++    assert.strictEqual(this.tweetParam('url'), MOCK_URL.href);
 +  });
 +
 +  test('it supports passing @text', async function (assert) {

--- a/src/markdown/tutorial/part-2/10-service-injection.md
+++ b/src/markdown/tutorial/part-2/10-service-injection.md
@@ -350,7 +350,7 @@ While we are here, let's add some more tests for the various functionalities of 
 @@ -33,2 +36,51 @@
        .containsText('Tweet this!');
 +
-+    assert.equal(this.tweetParam('url'), MOCK_URL.href);
++    assert.strictEqual(this.tweetParam('url'), MOCK_URL.href);
 +  });
 +
 +  test('it supports passing @text', async function (assert) {
@@ -358,7 +358,7 @@ While we are here, let's add some more tests for the various functionalities of 
 +      hbs`<ShareButton @text="Hello Twitter!">Tweet this!</ShareButton>`
 +    );
 +
-+    assert.equal(this.tweetParam('text'), 'Hello Twitter!');
++    assert.strictEqual(this.tweetParam('text'), 'Hello Twitter!');
 +  });
 +
 +  test('it supports passing @hashtags', async function (assert) {
@@ -366,12 +366,12 @@ While we are here, let's add some more tests for the various functionalities of 
 +      hbs`<ShareButton @hashtags="foo,bar,baz">Tweet this!</ShareButton>`
 +    );
 +
-+    assert.equal(this.tweetParam('hashtags'), 'foo,bar,baz');
++    assert.strictEqual(this.tweetParam('hashtags'), 'foo,bar,baz');
 +  });
 +
 +  test('it supports passing @via', async function (assert) {
 +    await render(hbs`<ShareButton @via="emberjs">Tweet this!</ShareButton>`);
-+    assert.equal(this.tweetParam('via'), 'emberjs');
++    assert.strictEqual(this.tweetParam('via'), 'emberjs');
 +  });
 +
 +  test('it supports adding extra classes', async function (assert) {

--- a/src/markdown/tutorial/part-2/10-service-injection.md
+++ b/src/markdown/tutorial/part-2/10-service-injection.md
@@ -324,22 +324,20 @@ git add tests/integration/components/share-button-test.js
 While we are here, let's add some more tests for the various functionalities of the `<ShareButton>` component:
 
 ```run:file:patch lang=js cwd=super-rentals filename=tests/integration/components/share-button-test.js
-@@ -3,3 +3,3 @@
- import Service from '@ember/service';
+@@ -4 +4 @@ 
+import Service from '@ember/service';
 -import { render } from '@ember/test-helpers';
 +import { find, render } from '@ember/test-helpers';
- import { hbs } from 'ember-cli-htmlbars';
-@@ -17,2 +17,8 @@
-     this.owner.register('service:router', MockRouterService);
+@@ -17,0 +18,6 @@ module('Integration | Component | share-button', function (hooks) {
 +
 +    this.tweetParam = (param) => {
 +      let link = find('a');
 +      let url = new URL(link.href);
 +      return url.searchParams.get(param);
 +    };
-   });
-@@ -26,8 +32,3 @@
-       .hasAttribute('rel', 'external nofollow noopener noreferrer')
+@@ -25,7 +31 @@ 
+module('Integration | Component | share-button', function (hooks) {
+-      .hasAttribute('rel', 'external nofollow noopener noreferrer')
 -      .hasAttribute(
 -        'href',
 -        `https://twitter.com/intent/tweet?url=${encodeURIComponent(
@@ -347,14 +345,11 @@ While we are here, let's add some more tests for the various functionalities of 
 -        )}`
 -      )
 +      .hasAttribute('href', /^https:\/\/twitter\.com\/intent\/tweet/)
-       .hasClass('share')
-@@ -35,2 +36,53 @@
-       .containsText('Tweet this!');
+@@ -34,0 +35,50 @@ 
+module('Integration | Component | share-button', function (hooks) {
 +
-+    assert.strictEqual(
-+      this.tweetParam('url'),
-+      new URL('/foo/bar?baz=true#some-section', window.location.origin)
-+    );
++    let url = new URL('/foo/bar?baz=true#some-section', window.location.origin);
++    assert.strictEqual(this.tweetParam('url'), url.href);
 +  });
 +
 +  test('it supports passing @text', async function (assert) {
@@ -401,7 +396,6 @@ While we are here, let's add some more tests for the various functionalities of 
 +      .hasAttribute('target', '_blank')
 +      .hasAttribute('rel', 'external nofollow noopener noreferrer')
 +      .hasAttribute('href', /^https:\/\/twitter\.com\/intent\/tweet/);
-   });
 ```
 
 The main goal here is to test the key functionalities of the component individually. That way, if any of these features regresses in the future, these tests can help pinpoint the source of the problem for us. Because a lot of these tests require parsing the URL and accessing its query params, we setup our own `this.tweetParam` test helper function in the `beforeEach` hook. This pattern allows us to easily share functionality between tests. We were even able to refactor the previous test using this new helper!

--- a/src/markdown/tutorial/part-2/10-service-injection.md
+++ b/src/markdown/tutorial/part-2/10-service-injection.md
@@ -257,17 +257,16 @@ More importantly, services are designed to be easily *swappable*. In our compone
 
 We will take advantage of this capability in our component test:
 
-```run:file:patch lang=js cwd=super-rentals filename=tests/integration/components/share-button-test.js
 @@ -2,2 +2,3 @@
  import { setupRenderingTest } from 'ember-qunit';
 +import Service from '@ember/service';
  import { render } from '@ember/test-helpers';
-@@ -5,21 +6,31 @@
- 
+@@ -5,21 +6,33 @@ import { hbs } from 'ember-cli-htmlbars';
+
 -module('Integration | Component | share-button', function (hooks) {
 -  setupRenderingTest(hooks);
 +const MOCK_URL = new URL('/foo/bar?baz=true#some-section', window.location.origin);
- 
+
 -  test('it renders', async function (assert) {
 -    // Set any properties with this.set('myProperty', 'value');
 -    // Handle any actions with this.set('myAction', function(val) { ... });
@@ -276,15 +275,16 @@ We will take advantage of this capability in our component test:
 +    return '/foo/bar?baz=true#some-section';
 +  }
 +}
- 
+
 -    await render(hbs`<ShareButton />`);
 +module('Integration | Component | share-button', function (hooks) {
 +  setupRenderingTest(hooks);
- 
+
 -    assert.dom(this.element).hasText('');
 +  hooks.beforeEach(function () {
 +    this.owner.register('service:router', MockRouterService);
 +  });
+
 -    // Template block usage:
 -    await render(hbs`
 -      <ShareButton>
@@ -293,6 +293,7 @@ We will take advantage of this capability in our component test:
 -    `);
 +  test('basic usage', async function (assert) {
 +    await render(hbs`<ShareButton>Tweet this!</ShareButton>`);
+
 -    assert.dom(this.element).hasText('template block text');
 +    assert
 +      .dom('a')
@@ -300,13 +301,14 @@ We will take advantage of this capability in our component test:
 +      .hasAttribute('rel', 'external nofollow noopener noreferrer')
 +      .hasAttribute(
 +        'href',
-+        `https://twitter.com/intent/tweet?url=${encodeURIComponent(MOCK_URL.href)}`
++        `https://twitter.com/intent/tweet?url=${encodeURIComponent(
++          new URL('/foo/bar?baz=true#some-section', window.location.origin)
++        )}`
 +      )
 +      .hasClass('share')
 +      .hasClass('button')
 +      .containsText('Tweet this!');
    });
-```
 
 In this component test, we *[registered](../../../applications/dependency-injection/#toc_factory-registrations)* our own router service with Ember in the `beforeEach` hook. When our component is rendered and requests the router service to be injected, it will get an instance of our `MockRouterService` instead of the built-in router service.
 
@@ -336,18 +338,20 @@ While we are here, let's add some more tests for the various functionalities of 
 +      return url.searchParams.get(param);
 +    };
    });
-@@ -26,6 +32,3 @@
+@@ -28,8 +34,3 @@
        .hasAttribute('rel', 'external nofollow noopener noreferrer')
 -      .hasAttribute(
 -        'href',
--        `https://twitter.com/intent/tweet?url=${encodeURIComponent(MOCK_URL.href)}`
+-        `https://twitter.com/intent/tweet?url=${encodeURIComponent(
+-          new URL('/foo/bar?baz=true#some-section', window.location.origin)
+-        )}`
 -      )
 +      .hasAttribute('href', /^https:\/\/twitter\.com\/intent\/tweet/)
        .hasClass('share')
-@@ -35,2 +38,50 @@
+@@ -37,2 +38,50 @@
        .containsText('Tweet this!');
 +
-+    assert.strictEqual(this.tweetParam('url'), MOCK_URL.href);
++      assert.strictEqual(this.tweetParam('url'), MOCK_URL.href);
 +  });
 +
 +  test('it supports passing @text', async function (assert) {

--- a/src/markdown/tutorial/part-2/10-service-injection.md
+++ b/src/markdown/tutorial/part-2/10-service-injection.md
@@ -262,31 +262,30 @@ We will take advantage of this capability in our component test:
  import { setupRenderingTest } from 'ember-qunit';
 +import Service from '@ember/service';
  import { render } from '@ember/test-helpers';
-@@ -5,2 +6,11 @@
-
-+
+@@ -5,21 +6,31 @@
+ 
+-module('Integration | Component | share-button', function (hooks) {
+-  setupRenderingTest(hooks);
 +const MOCK_URL = new URL('/foo/bar?baz=true#some-section', window.location.origin);
-+
+ 
+-  test('it renders', async function (assert) {
+-    // Set any properties with this.set('myProperty', 'value');
+-    // Handle any actions with this.set('myAction', function(val) { ... });
 +class MockRouterService extends Service {
 +  get currentURL() {
 +    return '/foo/bar?baz=true#some-section';
 +  }
 +}
-+
- module('Integration | Component | share-button', function (hooks) {
-@@ -8,18 +15,20 @@
-
--  test('it renders', async function (assert) {
--    // Set any properties with this.set('myProperty', 'value');
--    // Handle any actions with this.set('myAction', function(val) { ... });
--
+ 
 -    await render(hbs`<ShareButton />`);
--
++module('Integration | Component | share-button', function (hooks) {
++  setupRenderingTest(hooks);
+ 
 -    assert.dom(this.element).hasText('');
 +  hooks.beforeEach(function () {
 +    this.owner.register('service:router', MockRouterService);
 +  });
-
+ 
 -    // Template block usage:
 -    await render(hbs`
 -      <ShareButton>
@@ -295,7 +294,7 @@ We will take advantage of this capability in our component test:
 -    `);
 +  test('basic usage', async function (assert) {
 +    await render(hbs`<ShareButton>Tweet this!</ShareButton>`);
-
+ 
 -    assert.dom(this.element).hasText('template block text');
 +    assert
 +      .dom('a')
@@ -330,7 +329,7 @@ While we are here, let's add some more tests for the various functionalities of 
 -import { render } from '@ember/test-helpers';
 +import { find, render } from '@ember/test-helpers';
  import { hbs } from 'ember-cli-htmlbars';
-@@ -17,2 +17,8 @@
+@@ -19,2 +19,8 @@
      this.owner.register('service:router', MockRouterService);
 +
 +    this.tweetParam = (param) => {
@@ -347,7 +346,7 @@ While we are here, let's add some more tests for the various functionalities of 
 -      )
 +      .hasAttribute('href', /^https:\/\/twitter\.com\/intent\/tweet/)
        .hasClass('share')
-@@ -33,2 +36,51 @@
+@@ -35,2 +38,50 @@
        .containsText('Tweet this!');
 +
 +    assert.strictEqual(this.tweetParam('url'), MOCK_URL.href);

--- a/src/markdown/tutorial/part-2/10-service-injection.md
+++ b/src/markdown/tutorial/part-2/10-service-injection.md
@@ -257,11 +257,12 @@ More importantly, services are designed to be easily *swappable*. In our compone
 
 We will take advantage of this capability in our component test:
 
+```run:file:patch lang=js cwd=super-rentals filename=tests/integration/components/share-button-test.js
 @@ -2,2 +2,3 @@
  import { setupRenderingTest } from 'ember-qunit';
 +import Service from '@ember/service';
  import { render } from '@ember/test-helpers';
-@@ -5,21 +6,33 @@ import { hbs } from 'ember-cli-htmlbars';
+@@ -5,21 +6,31 @@ import { hbs } from 'ember-cli-htmlbars';
 
 -module('Integration | Component | share-button', function (hooks) {
 -  setupRenderingTest(hooks);
@@ -301,14 +302,13 @@ We will take advantage of this capability in our component test:
 +      .hasAttribute('rel', 'external nofollow noopener noreferrer')
 +      .hasAttribute(
 +        'href',
-+        `https://twitter.com/intent/tweet?url=${encodeURIComponent(
-+          new URL('/foo/bar?baz=true#some-section', window.location.origin)
-+        )}`
++        `https://twitter.com/intent/tweet?url=${encodeURIComponent(MOCK_URL.href)}`
 +      )
 +      .hasClass('share')
 +      .hasClass('button')
 +      .containsText('Tweet this!');
    });
+```
 
 In this component test, we *[registered](../../../applications/dependency-injection/#toc_factory-registrations)* our own router service with Ember in the `beforeEach` hook. When our component is rendered and requests the router service to be injected, it will get an instance of our `MockRouterService` instead of the built-in router service.
 
@@ -338,17 +338,15 @@ While we are here, let's add some more tests for the various functionalities of 
 +      return url.searchParams.get(param);
 +    };
    });
-@@ -28,8 +34,3 @@
+@@ -28,6 +34,3 @@
        .hasAttribute('rel', 'external nofollow noopener noreferrer')
 -      .hasAttribute(
 -        'href',
--        `https://twitter.com/intent/tweet?url=${encodeURIComponent(
--          new URL('/foo/bar?baz=true#some-section', window.location.origin)
--        )}`
+-        `https://twitter.com/intent/tweet?url=${encodeURIComponent(MOCK_URL.href)}`
 -      )
 +      .hasAttribute('href', /^https:\/\/twitter\.com\/intent\/tweet/)
        .hasClass('share')
-@@ -37,2 +38,50 @@
+@@ -35,2 +38,50 @@
        .containsText('Tweet this!');
 +
 +      assert.strictEqual(this.tweetParam('url'), MOCK_URL.href);

--- a/src/markdown/tutorial/part-2/10-service-injection.md
+++ b/src/markdown/tutorial/part-2/10-service-injection.md
@@ -285,7 +285,6 @@ We will take advantage of this capability in our component test:
 +  hooks.beforeEach(function () {
 +    this.owner.register('service:router', MockRouterService);
 +  });
- 
 -    // Template block usage:
 -    await render(hbs`
 -      <ShareButton>
@@ -294,7 +293,6 @@ We will take advantage of this capability in our component test:
 -    `);
 +  test('basic usage', async function (assert) {
 +    await render(hbs`<ShareButton>Tweet this!</ShareButton>`);
- 
 -    assert.dom(this.element).hasText('template block text');
 +    assert
 +      .dom('a')

--- a/src/markdown/tutorial/part-2/10-service-injection.md
+++ b/src/markdown/tutorial/part-2/10-service-injection.md
@@ -262,9 +262,12 @@ We will take advantage of this capability in our component test:
  import { setupRenderingTest } from 'ember-qunit';
 +import Service from '@ember/service';
  import { render } from '@ember/test-helpers';
-@@ -5,2 +6,10 @@
+@@ -5,2 +6,13 @@
 
-+const MOCK_URL = new URL('/foo/bar?baz=true#some-section', window.location.origin);
++const MOCK_URL = new URL(
++  '/foo/bar?baz=true#some-section',
++  window.location.origin
++);
 +
 +class MockRouterService extends Service {
 +  get currentURL() {
@@ -273,7 +276,7 @@ We will take advantage of this capability in our component test:
 +}
 +
  module('Integration | Component | share-button', function (hooks) {
-@@ -8,18 +17,20 @@
+@@ -8,18 +20,20 @@
 
 -  test('it renders', async function (assert) {
 -    // Set any properties with this.set('myProperty', 'value');
@@ -329,7 +332,7 @@ While we are here, let's add some more tests for the various functionalities of 
 -import { render } from '@ember/test-helpers';
 +import { find, render } from '@ember/test-helpers';
  import { hbs } from 'ember-cli-htmlbars';
-@@ -19,2 +19,8 @@
+@@ -22,2 +22,8 @@
      this.owner.register('service:router', MockRouterService);
 +
 +    this.tweetParam = (param) => {
@@ -338,7 +341,7 @@ While we are here, let's add some more tests for the various functionalities of 
 +      return url.searchParams.get(param);
 +    };
    });
-@@ -28,6 +34,3 @@
+@@ -31,6 +37,3 @@
        .hasAttribute('rel', 'external nofollow noopener noreferrer')
 -      .hasAttribute(
 -        'href',
@@ -346,7 +349,7 @@ While we are here, let's add some more tests for the various functionalities of 
 -      )
 +      .hasAttribute('href', /^https:\/\/twitter\.com\/intent\/tweet/)
        .hasClass('share')
-@@ -35,2 +38,50 @@
+@@ -38,2 +41,50 @@
        .containsText('Tweet this!');
 +
 +      assert.strictEqual(this.tweetParam('url'), MOCK_URL.href);

--- a/src/markdown/tutorial/part-2/10-service-injection.md
+++ b/src/markdown/tutorial/part-2/10-service-injection.md
@@ -328,7 +328,8 @@ While we are here, let's add some more tests for the various functionalities of 
 import Service from '@ember/service';
 -import { render } from '@ember/test-helpers';
 +import { find, render } from '@ember/test-helpers';
-@@ -17,0 +18,6 @@ module('Integration | Component | share-button', function (hooks) {
+@@ -17,0 +18,6 @@ 
+module('Integration | Component | share-button', function (hooks) {
 +
 +    this.tweetParam = (param) => {
 +      let link = find('a');

--- a/src/markdown/tutorial/part-2/11-ember-data.md
+++ b/src/markdown/tutorial/part-2/11-ember-data.md
@@ -129,19 +129,19 @@ The generator created some boilerplate code for us, which serves as a pretty goo
 +        'This grand old mansion sits on over 100 acres of rolling hills and dense redwood forests.',
 +    });
 +
-+    assert.equal(rental.type, 'Standalone');
++    assert.strictEqual(rental.type, 'Standalone');
 +
 +    rental.category = 'Condo';
-+    assert.equal(rental.type, 'Community');
++    assert.strictEqual(rental.type, 'Community');
 +
 +    rental.category = 'Townhouse';
-+    assert.equal(rental.type, 'Community');
++    assert.strictEqual(rental.type, 'Community');
 +
 +    rental.category = 'Apartment';
-+    assert.equal(rental.type, 'Community');
++    assert.strictEqual(rental.type, 'Community');
 +
 +    rental.category = 'Estate';
-+    assert.equal(rental.type, 'Standalone');
++    assert.strictEqual(rental.type, 'Standalone');
    });
 ```
 


### PR DESCRIPTION

See https://github.com/ember-cli/ember-cli/pull/9667