### PR TITLE
Restore CI for release -- should only merge after Ember v4 is released

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         channel:
           - release
-          - beta
+          # - beta TODO re-enable once CLI no longer has deprecated behavior on generation
     steps:
       - name: Set up Git
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         channel:
-          # - release TODO: Re-enable once 4.0 is released
+          - release
           - beta
     steps:
       - name: Set up Git


### PR DESCRIPTION
Restores running CI for release. Should only be merged once this PR is green after the release of Ember 4.0