### PR TITLE
Re-enable beta tutorial build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         channel:
           - release
-          # - beta TODO re-enable once CLI no longer has deprecated behavior on generation
+          - beta
     steps:
       - name: Set up Git
         run: |


### PR DESCRIPTION
Should pass once https://github.com/ember-cli/ember-cli/pull/9739 is released in a CLI beta release