### PR TITLE
Fix the "deterministic tests" hack

### DIFF
--- a/src/markdown/tutorial/part-1/01-orientation.md
+++ b/src/markdown/tutorial/part-1/01-orientation.md
@@ -98,7 +98,7 @@ del package.json
 ```
 
 ```run:file:patch hidden=true cwd=super-rentals filename=tests/index.html
-@@ -28,2 +28,91 @@
+@@ -28,2 +28,93 @@
      <script src="{{rootURL}}assets/tests.js"></script>
 +    <script>
 +      if (QUnit.urlParams.deterministic) {
@@ -178,14 +178,16 @@ del package.json
 +          }
 +        });
 +
-+        QUnit.config.callbacks.done.unshift(details => {
-+          details.runtime = totalRuntime;
-+        });
-+
 +        QUnit.begin(details => {
 +          let ua = document.getElementById('qunit-userAgent');
 +          ua.innerText = ua.innerText.replace(/QUnit [0-9\.]+/g, 'QUnit');
 +          ua.innerText = ua.innerText.replace(/(WebKit|Chrome|Safari)\/[0-9\.]+/g, '$1');
++        });
++
++        QUnit.on('runEnd', () => {
++          let display = document.getElementById('qunit-testresult-display');
++          display.innerText = display.innerText
++            .replace(/in [.0-9]+ milliseconds/, `in ${totalRuntime} milliseconds`);
 +        });
 +      }
 +    </script>


### PR DESCRIPTION
QUnit's reporter was refactored to use the new `runEnd` event[1]. This broke the previous hack as modifying the `details` object in the `done` hook no longer does anything.

[1]: https://github.com/qunitjs/qunit/pull/1643