### PR TITLE
add a threshold to perceptualdiff to prevent so much image churn

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -224,7 +224,7 @@ jobs:
                 echo "$dest (unchanged)"
                 cp "$prev" "$dest"
                 return 0
-              elif perceptualdiff --output "$diff" --downsample 2 --colorfactor 0.5 "$prev" "$src" > /dev/null; then
+              elif perceptualdiff --output "$diff" --downsample 2 --colorfactor 0.5 --threshold 1000 "$prev" "$src" > /dev/null; then
                 echo "$dest (unchanged)"
                 cp "$prev" "$dest"
                 return 0


### PR DESCRIPTION
Myself and @jaredgalanis did some investigation on this and found that some of the noise that is happening because of slight differences in the maps would be under the threshold of 1000 pixels different. This might be tweaked later but I think we should try this for a little while