### PR TITLE
include hidden `.git` files in artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,7 @@ jobs:
         with:
           name: code (${{ matrix.channel }})
           path: dist/code/super-rentals
+          include-hidden-files: true
       - name: Notify Discord
         uses: sarisia/actions-status-discord@v1
         if: ${{ failure() && github.event_name == 'schedule' }}


### PR DESCRIPTION
This was a breaking change in the `actions/upload-artifact` action that they pushed into the v3 minor for security reasons.

See: https://github.com/actions/upload-artifact/pull/604