### PR TITLE
Strict mode

### DIFF
--- a/src/markdown/tutorial/part-1/01-orientation.md
+++ b/src/markdown/tutorial/part-1/01-orientation.md
@@ -46,12 +46,12 @@ Hack: make an empty package.json to convince ember-cli we are really not in an E
 # pretend we are running NPM.
 
 #[cfg(all(ci, unix))]
-#[display(ember new super-rentals --lang en)]
-ember new super-rentals --lang en --pnpm \
+#[display(ember new super-rentals --lang en --strict)]
+ember new super-rentals --lang en --strict --pnpm \
   | awk '{ gsub("Pnpm", "npm"); gsub("pnpm", "npm"); print }'
 
 #[cfg(not(all(ci, unix)))]
-ember new super-rentals --lang en --pnpm
+ember new super-rentals --lang en --strict --pnpm
 ```
 
 ```run:command hidden=true
@@ -196,7 +196,7 @@ del package.json
 
 ```run:file:patch hidden=true cwd=super-rentals filename=.prettierignore
 @@ -1 +1,2 @@
-+**/*.hbs
++**/*.gjs
  # unconventional js
 
 ```
@@ -277,20 +277,24 @@ You can exit out of the development server at any time by typing `Ctrl + C` into
 
 The development server has a feature called *live reload*, which monitors your app for file changes, automatically re-compiles everything, and refreshes any open browser pages. This comes in really handy during development, so let's give that a try!
 
-As text on the welcome page pointed out, the source code for the page is located in `app/templates/application.hbs`. Let's try to edit that file and replace it with our own content:
+As text on the welcome page pointed out, the source code for the page is located in `app/templates/application.gjs`. Let's try to edit that file and replace it with our own content:
 
-```run:file:patch lang=handlebars cwd=super-rentals filename=app/templates/application.hbs
-@@ -1,7 +1 @@
--{{page-title "SuperRentals"}}
+```run:file:patch lang=gjs cwd=super-rentals filename=app/templates/application.gjs
+@@ -1,12 +1,3 @@
+-import pageTitle from 'ember-page-title/helpers/page-title';
+-import WelcomePage from 'ember-welcome-page/components/welcome-page';
 -
--{{outlet}}
+ <template>
+-  {{pageTitle "SuperRentals"}}
 -
--{{! The following component displays Ember's default welcome message. }}
--<WelcomePage />
--{{! Feel free to remove this! }}
-\ No newline at end of file
-+Hello World!!!
-```
+-  {{outlet}}
+-
+-  {{! The following component displays Ember's default welcome message. }}
+-  <WelcomePage />
+-  {{! Feel free to remove this! }}
++  Hello World!!!
+ </template>
+ ```
 
 Soon after saving the file, your browser should automatically refresh and render our greetings to the world. Neat!
 
@@ -298,27 +302,29 @@ Soon after saving the file, your browser should automatically refresh and render
 visit http://localhost:4200/?deterministic
 ```
 
-When you are done experimenting, go ahead and delete the `app/templates/application.hbs` file. We won't be needing this for a while, so let's start afresh. We can add it back later when we have a need for it.
+When you are done experimenting, go ahead and delete the `app/templates/application.gjs` file. We won't be needing this for a while, so let's start afresh. We can add it back later when we have a need for it.
 
 ```run:command hidden=true cwd=super-rentals
-git rm -f app/templates/application.hbs
+git rm -f app/templates/application.gjs
 ```
 
 Again, if you still have your browser tab open, your tab will automatically re-render a blank page as soon as you delete the file. This reflects the fact that we no longer have an application template in our app.
 
 ## Working with HTML, CSS and Assets in an Ember App
 
-Create a `app/templates/index.hbs` file and paste the following markup.
+Create a `app/templates/index.gjs` file and paste the following markup.
 
-```run:file:create lang=handlebars cwd=super-rentals filename=app/templates/index.hbs
-<div class="jumbo">
-  <div class="right tomster"></div>
-  <h2>Welcome to Super Rentals!</h2>
-  <p>We hope you find exactly what you're looking for in a place to stay.</p>
-</div>
+```run:file:create lang=gjs cwd=super-rentals filename=app/templates/index.gjs
+<template>
+  <div class="jumbo">
+    <div class="right tomster"></div>
+    <h2>Welcome to Super Rentals!</h2>
+    <p>We hope you find exactly what you're looking for in a place to stay.</p>
+  </div>
+</template>
 ```
 
-If you are thinking, "Hey, that looks like HTML!", then you would be right! In their simplest form, Ember templates are really just HTML. If you are already familiar with HTML, you should feel right at home here.
+If you are thinking, "Hey, that looks like HTML!", then you would be right! In their simplest form, Ember templates are really just HTML wrapped in a `<template>` tag. If you are already familiar with HTML, you should feel right at home here.
 
 Of course, unlike HTML, Ember templates can do a lot more than just displaying static content. We will see that in action soon.
 
@@ -329,7 +335,7 @@ visit http://localhost:4200/?deterministic
 ```
 
 ```run:command hidden=true cwd=super-rentals
-git add app/templates/index.hbs
+git add app/templates/index.gjs
 ```
 
 Before we do anything else, let's add some styling to our app. We spend enough time staring at the computer screen as it is, so we must protect our eyesight against unstyled markup!

--- a/src/markdown/tutorial/part-1/02-building-pages.md
+++ b/src/markdown/tutorial/part-1/02-building-pages.md
@@ -45,18 +45,20 @@ git add app/router.js
 
 ## Using Route Templates
 
-With that in place, we can create a new `app/templates/about.hbs` template with the following content:
+With that in place, we can create a new `app/templates/about.gjs` template with the following content:
 
-```run:file:create lang=handlebars cwd=super-rentals filename=app/templates/about.hbs
-<div class="jumbo">
-  <div class="right tomster"></div>
-  <h2>About Super Rentals</h2>
-  <p>
-    The Super Rentals website is a delightful project created to explore Ember.
-    By building a property rental site, we can simultaneously imagine traveling
-    AND building Ember applications.
-  </p>
-</div>
+```run:file:create lang=gjs cwd=super-rentals filename=app/templates/about.gjs
+<template>
+  <div class="jumbo">
+    <div class="right tomster"></div>
+    <h2>About Super Rentals</h2>
+    <p>
+      The Super Rentals website is a delightful project created to explore Ember.
+      By building a property rental site, we can simultaneously imagine traveling
+      AND building Ember applications.
+    </p>
+  </div>
+</template>
 ```
 
 To see this in action, navigate to `http://localhost:4200/about`.
@@ -66,7 +68,7 @@ visit http://localhost:4200/about?deterministic
 ```
 
 ```run:command hidden=true cwd=super-rentals
-git add app/templates/about.hbs
+git add app/templates/about.gjs
 ```
 
 With that, our second page is done!
@@ -90,26 +92,28 @@ Here, we added the `contact` route, but explicitly specified a path for the rout
 git add app/router.js
 ```
 
-Speaking of the template, let's create that as well. We'll add a `app/templates/contact.hbs` file:
+Speaking of the template, let's create that as well. We'll add a `app/templates/contact.gjs` file:
 
-```run:file:create lang=handlebars cwd=super-rentals filename=app/templates/contact.hbs
-<div class="jumbo">
-  <div class="right tomster"></div>
-  <h2>Contact Us</h2>
-  <p>
-    Super Rentals Representatives would love to help you<br>
-    choose a destination or answer any questions you may have.
-  </p>
-  <address>
-    Super Rentals HQ
+```run:file:create lang=gjs cwd=super-rentals filename=app/templates/contact.gjs
+<template>
+  <div class="jumbo">
+    <div class="right tomster"></div>
+    <h2>Contact Us</h2>
     <p>
-      1212 Test Address Avenue<br>
-      Testington, OR 97233
+      Super Rentals Representatives would love to help you<br>
+      choose a destination or answer any questions you may have.
     </p>
-    <a href="tel:503.555.1212">+1 (503) 555-1212</a><br>
-    <a href="mailto:superrentalsrep@emberjs.com">superrentalsrep@emberjs.com</a>
-  </address>
-</div>
+    <address>
+      Super Rentals HQ
+      <p>
+        1212 Test Address Avenue<br>
+        Testington, OR 97233
+      </p>
+      <a href="tel:503.555.1212">+1 (503) 555-1212</a><br>
+      <a href="mailto:superrentalsrep@emberjs.com">superrentalsrep@emberjs.com</a>
+    </address>
+  </div>
+</template>
 ```
 
 Ember comes with strong *[conventions][TODO: link to conventions]* and sensible defaults&mdash;if we were starting from scratch, we wouldn't mind the default `/contact` URL. However, if the defaults don't work for us, it is no problem at all to customize Ember for our needs!
@@ -121,7 +125,7 @@ visit http://localhost:4200/getting-in-touch?deterministic
 ```
 
 ```run:command hidden=true cwd=super-rentals
-git add app/templates/contact.hbs
+git add app/templates/contact.gjs
 ```
 
 ## Linking Pages with the `<LinkTo>` Component
@@ -132,30 +136,43 @@ Since Ember offers great support for URLs out-of-the-box, we *could* just link o
 
 With Ember, we can do better than that! Instead of the plain-old `<a>` tag, Ember provides an alternative called `<LinkTo>`. For example, here is how you would use it on the pages we just created:
 
-```run:file:patch lang=handlebars cwd=super-rentals filename=app/templates/index.hbs
-@@ -4,2 +4,3 @@
-   <p>We hope you find exactly what you're looking for in a place to stay.</p>
-+  <LinkTo @route="about" class="button">About Us</LinkTo>
- </div>
+```run:file:patch lang=gjs cwd=super-rentals filename=app/templates/index.gjs
+@@ -1 +1,3 @@
++import { LinkTo } from '@ember/routing'; 
++
+ <template>
+@@ -5,2 +7,3 @@
+     <p>We hope you find exactly what you're looking for in a place to stay.</p>
++    <LinkTo @route="about" class="button">About Us</LinkTo>
+   </div>
 ```
 
-```run:file:patch lang=handlebars cwd=super-rentals filename=app/templates/about.hbs
-@@ -8,2 +8,3 @@
-   </p>
-+  <LinkTo @route="contact" class="button">Contact Us</LinkTo>
- </div>
+```run:file:patch lang=gjs cwd=super-rentals filename=app/templates/about.gjs
+@@ -1 +1,3 @@
++import { LinkTo } from '@ember/routing'; 
++
+ <template>
+@@ -9,2 +11,3 @@
+     </p>
++    <LinkTo @route="contact" class="button">Contact Us</LinkTo>
+   </div>
 ```
 
-```run:file:patch lang=handlebars cwd=super-rentals filename=app/templates/contact.hbs
-@@ -16,2 +16,3 @@
-   </address>
-+  <LinkTo @route="about" class="button">About</LinkTo>
- </div>
+```run:file:patch lang=gjs cwd=super-rentals filename=app/templates/contact.gjs
+@@ -1 +1,3 @@
++import { LinkTo } from '@ember/routing'; 
++
+ <template>
+@@ -17,2 +19,3 @@
+     </address>
++    <LinkTo @route="about" class="button">About</LinkTo>
+   </div>
 ```
+
 
 There is quite a bit going on here, so let's break it down.
 
-`<LinkTo>` is an example of a *[component](../../../components/introducing-components/)* in Ember&mdash;you can tell them apart from regular HTML tags because they start with an uppercase letter. Along with regular HTML tags, components are a key building block that we can use to build up an app's user interface.
+`<LinkTo>` is an example of a *[component](../../../components/introducing-components/)* in Ember. Along with regular HTML tags, components are a key building block that we can use to build up an app's user interface. Unlike regular HTML tags, components need to be imported before they can be used. In this case, `<LinkTo>` is imported from the `@ember/routing` package that is part of Ember.
 
 We have a lot more to say about components later, but for now, you can think of them as a way to provide *[custom tags][TODO: link to custom tags]* to supplement the built-in ones that came with the browser.
 
@@ -182,9 +199,9 @@ visit http://localhost:4200/getting-in-touch?deterministic
 ```
 
 ```run:command hidden=true cwd=super-rentals
-git add app/templates/index.hbs
-git add app/templates/about.hbs
-git add app/templates/contact.hbs
+git add app/templates/index.gjs
+git add app/templates/about.gjs
+git add app/templates/contact.gjs
 ```
 
 We will learn more about how all of this works soon. In the meantime, go ahead and click on the link in the browser. Did you notice how snappy that was?

--- a/src/markdown/tutorial/part-1/03-automated-testing.md
+++ b/src/markdown/tutorial/part-1/03-automated-testing.md
@@ -120,13 +120,17 @@ wait  #qunit-banner.qunit-pass
 
 It happens really quickly though&mdash;blink and you might miss it! In fact, I had to slow this animation down by a hundred times just so you can see it in action. I told you the robot has really, really fast hands!
 
-As much as I enjoy watching this robot hard at work, the important thing here is that the test we wrote has *[passed][TODO: link to passed]*, meaning everything is working exactly as we expect and the test UI is all green and happy. If you want, you can go to `index.hbs`, delete the `<LinkTo>` component and see what things look like when we have *[a failing test][TODO: link to a failing test]*.
+As much as I enjoy watching this robot hard at work, the important thing here is that the test we wrote has *[passed][TODO: link to passed]*, meaning everything is working exactly as we expect and the test UI is all green and happy. If you want, you can go to `index.gjs`, delete the `<LinkTo>` component and see what things look like when we have *[a failing test][TODO: link to a failing test]*.
 
-```run:file:patch hidden=true cwd=super-rentals filename=app/templates/index.hbs
-@@ -4,3 +4,2 @@
-   <p>We hope you find exactly what you're looking for in a place to stay.</p>
--  <LinkTo @route="about" class="button">About Us</LinkTo>
- </div>
+```run:file:patch hidden=true cwd=super-rentals filename=app/templates/index.gjs
+@@ -1,3 +1 @@
+-import { LinkTo } from '@ember/routing'; 
+-
+ <template>
+@@ -7,3 +5,2 @@ import { LinkTo } from '@ember/routing';
+     <p>We hope you find exactly what you're looking for in a place to stay.</p>
+-    <LinkTo @route="about" class="button">About Us</LinkTo>
+   </div>
 ```
 
 ```run:screenshot width=1024 height=768 retina=true filename=fail.png alt="A failing test"
@@ -137,7 +141,7 @@ wait  #qunit-banner.qunit-fail
 Don't forget to put that line back in when you are done!
 
 ```run:command hidden=true cwd=super-rentals
-git checkout app/templates/index.hbs
+git checkout app/templates/index.gjs
 ember test --path dist
 ```
 

--- a/src/markdown/tutorial/part-1/04-component-basics.md
+++ b/src/markdown/tutorial/part-1/04-component-basics.md
@@ -163,36 +163,32 @@ Here, we used the generator to generate a *[component test](../../../testing/tes
 
 Let's replace the boilerplate code that was generated for us with our own test:
 
-```run:pause
-CHECK YO SELF - tests
-```
-
-
-```run:file:patch lang=js cwd=super-rentals filename=tests/integration/components/jumbo-test.js
-@@ -8,18 +8,8 @@
-
+```run:file:patch lang=js cwd=super-rentals filename=tests/integration/components/jumbo-test.gjs
+@@ -8,20 +8,10 @@ module('Integration | Component | jumbo', function (hooks) {
+ 
 -  test('it renders', async function (assert) {
--    // Set any properties with this.set('myProperty', 'value');
--    // Handle any actions with this.set('myAction', function(val) { ... });
+-    // Updating values is achieved using autotracking, just like in app code. For example:
+-    // class State { @tracked myProperty = 0; }; const state = new State();
+-    // and update using state.myProperty = 1; await rerender();
+-    // Handle any actions with function myAction(val) { ... };
 -
--    await render(hbs`<Jumbo />`);
+-    await render(<template><Jumbo /></template>);
 -
 -    assert.dom().hasText('');
 -
 -    // Template block usage:
--    await render(hbs`
++  test('it renders the content inside a jumbo header with a tomster', async function (assert) {
+     await render(<template>
 -      <Jumbo>
 -        template block text
 -      </Jumbo>
--    `);
--
++      <Jumbo>Hello World</Jumbo>
+     </template>);
+ 
 -    assert.dom().hasText('template block text');
-+  test('it renders the content inside a jumbo header with a tomster', async function (assert) {
-+    await render(hbs`<Jumbo>Hello World</Jumbo>`);
-+
 +    assert.dom('.jumbo').exists();
 +    assert.dom('.jumbo').hasText('Hello World');
-+    assert.dom('.jumbo .tomster').exists();
++    assert.dom('.jumbo .tomster').exists();  
    });
 ```
 
@@ -202,7 +198,7 @@ Just like visit and click, which we used earlier, render is also an async step, 
 
 ```run:command hidden=true cwd=super-rentals
 ember test --path dist
-git add tests/integration/components/jumbo-test.js
+git add tests/integration/components/jumbo-test.gjs
 ```
 
 ```run:screenshot width=1024 height=512 retina=true filename=pass-3.png alt="Tests still passing with our component test"
@@ -212,46 +208,62 @@ wait  #qunit-banner.qunit-pass
 
 We've been refactoring our existing code for a while, so let's change gears and implement a new feature: the site-wide navigation bar.
 
-We can create a `<NavBar>` component at `app/components/nav-bar.hbs`:
+We can create a `<NavBar>` component at `app/components/nav-bar.gjs`:
 
-```run:file:create lang=handlebars cwd=super-rentals filename=app/components/nav-bar.hbs
-<nav class="menu">
-  <LinkTo @route="index" class="menu-index">
-    <h1>SuperRentals</h1>
-  </LinkTo>
-  <div class="links">
-    <LinkTo @route="about" class="menu-about">
-      About
+```run:file:create lang=gjs cwd=super-rentals filename=app/components/nav-bar.gjs
+import { LinkTo } from '@ember/routing'; 
+
+<template>
+  <nav class="menu">
+    <LinkTo @route="index" class="menu-index">
+      <h1>SuperRentals</h1>
     </LinkTo>
-    <LinkTo @route="contact" class="menu-contact">
-      Contact
-    </LinkTo>
-  </div>
-</nav>
+    <div class="links">
+      <LinkTo @route="about" class="menu-about">
+        About
+      </LinkTo>
+      <LinkTo @route="contact" class="menu-contact">
+        Contact
+      </LinkTo>
+    </div>
+  </nav>
+<template>
 ```
 
 ```run:command hidden=true cwd=super-rentals
-git add app/components/nav-bar.hbs
+git add app/components/nav-bar.gjs
 ```
 
 Next, we will add our `<NavBar>` component to the top of each page:
 
-```run:file:patch lang=handlebars cwd=super-rentals filename=app/templates/about.hbs
-@@ -1 +1,2 @@
-+<NavBar />
- <Jumbo>
+```run:file:patch lang=gjs cwd=super-rentals filename=app/templates/about.gjs
+@@ -2,4 +2,6 @@ import { LinkTo } from '@ember/routing';
+ import Jumbo from 'super-rentals/components/jumbo';
++import NavBar from 'super-rentals/components/nav-bar';
+ 
+ <template>
++  <NavBar />
+   <Jumbo>
 ```
 
-```run:file:patch lang=handlebars cwd=super-rentals filename=app/templates/contact.hbs
-@@ -1 +1,2 @@
-+<NavBar />
- <Jumbo>
+```run:file:patch lang=gjs cwd=super-rentals filename=app/templates/contact.gjs
+@@ -2,4 +2,6 @@ import { LinkTo } from '@ember/routing';
+ import Jumbo from 'super-rentals/components/jumbo';
++import NavBar from 'super-rentals/components/nav-bar';
+ 
+ <template>
++  <NavBar />
+   <Jumbo>
 ```
 
-```run:file:patch lang=handlebars cwd=super-rentals filename=app/templates/index.hbs
-@@ -1 +1,2 @@
-+<NavBar />
- <Jumbo>
+```run:file:patch lang=gjs cwd=super-rentals filename=app/templates/index.gjs
+@@ -2,4 +2,6 @@ import { LinkTo } from '@ember/routing';
+ import Jumbo from 'super-rentals/components/jumbo';
++import NavBar from 'super-rentals/components/nav-bar';
+ 
+ <template>
++  <NavBar />
+   <Jumbo>
 ```
 
 Voilà, we made another component!
@@ -261,9 +273,9 @@ visit http://localhost:4200/?deterministic
 ```
 
 ```run:command hidden=true cwd=super-rentals
-git add app/templates/about.hbs
-git add app/templates/contact.hbs
-git add app/templates/index.hbs
+git add app/templates/about.gjs
+git add app/templates/contact.gjs
+git add app/templates/index.gjs
 ```
 
 > Zoey says...
@@ -337,14 +349,21 @@ This template is special in that it does not have its own URL and cannot be navi
 
 While we are at it, we will also add a container element that wraps around the whole page, as requested by our designer for styling purposes.
 
-```run:file:create lang=handlebars cwd=super-rentals filename=app/templates/application.hbs
-<div class="container">
-  <NavBar />
-  <div class="body">
-    {{outlet}}
+```run:file:create lang=gjs cwd=super-rentals filename=app/templates/application.gjs
+<template>
+  <div class="container">
+    <NavBar />
+    <div class="body">
+      {{outlet}}
+    </div>
   </div>
-</div>
+</template>
 ```
+
+```run:pause
+CHECK YO SELF - nav 
+```
+
 
 ```run:file:patch lang=handlebars cwd=super-rentals filename=app/templates/index.hbs
 @@ -1,2 +1 @@

--- a/src/markdown/tutorial/part-1/04-component-basics.md
+++ b/src/markdown/tutorial/part-1/04-component-basics.md
@@ -33,24 +33,22 @@ During the course of developing an app, it is pretty common to reuse the same UI
 
 Since it is not a lot of code, it may not seem like a big deal to duplicate this structure on each page. However, if our designer wanted us to make a change to the header, we would have to find and update every single copy of this code. As our app gets bigger, this will become even more of a problem.
 
-Components are the perfect solution to this. In its most basic form, a component is just a piece of template that can be referred to by name. Let's start by creating a new file at `app/components/jumbo.hbs` with markup for the "jumbo" header:
+Components are the perfect solution to this. In its most basic form, a component is just a piece of template that can be referred to by name. Let's start by creating a new file at `app/components/jumbo.gjs` with markup for the "jumbo" header:
 
-```run:file:create lang=handlebars cwd=super-rentals filename=app/components/jumbo.hbs
-<div class="jumbo">
-  <div class="right tomster"></div>
-  {{yield}}
-</div>
+```run:file:create lang=gjs cwd=super-rentals filename=app/components/jumbo.gjs
+<template>
+  <div class="jumbo">
+    <div class="right tomster"></div>
+    {{yield}}
+  </div>
+</template>
 ```
 
 ```run:command hidden=true cwd=super-rentals
-git add app/components/jumbo.hbs
+git add app/components/jumbo.gjs
 ```
 
-That's it, we have created our first component! We can now *[invoke][TODO: link to invoke]* this component anywhere in our app, using `<Jumbo>` as the tag name.
-
-> Zoey says...
->
-> Remember, when invoking components, we need to capitalize their names so Ember can tell them apart from regular HTML elements. The `jumbo.hbs` template corresponds to the `<Jumbo>` tag, just like `super-awesome.hbs` corresponds to `<SuperAwesome>`.
+That's it, we have created our first component! We can now *[invoke][TODO: link to invoke]* this component anywhere in our app, by importing it and using it like we saw with `<LinkTo>` previously.
 
 ## Passing Content to Components with `{{yield}}`
 
@@ -58,16 +56,22 @@ When invoking a component, Ember will replace the component tag with the content
 
 Let's try it out by editing the index template:
 
-```run:file:patch lang=handlebars cwd=super-rentals filename=app/templates/index.hbs
-@@ -1,3 +1,2 @@
--<div class="jumbo">
--  <div class="right tomster"></div>
-+<Jumbo>
-   <h2>Welcome to Super Rentals!</h2>
-@@ -5,2 +4,2 @@
-   <LinkTo @route="about" class="button">About Us</LinkTo>
--</div>
-+</Jumbo>
+```run:file:patch lang=gjs cwd=super-rentals filename=app/templates/index.gjs
+@@ -1,6 +1,6 @@
+-import { LinkTo } from '@ember/routing'; 
++import { LinkTo } from '@ember/routing';
++import Jumbo from 'super-rentals/components/jumbo';
+ 
+ <template>
+-  <div class="jumbo">
+-    <div class="right tomster"></div>
++  <Jumbo>
+     <h2>Welcome to Super Rentals!</h2>
+@@ -8,3 +8,3 @@ import { LinkTo } from '@ember/routing';
+     <LinkTo @route="about" class="button">About Us</LinkTo>
+-  </div>
++  </Jumbo>
+ </template>
 ```
 
 ## Refactoring Existing Code
@@ -85,45 +89,47 @@ wait  #qunit-banner.qunit-pass
 
 Let's do the same for our other two pages as well.
 
-```run:file:patch lang=handlebars cwd=super-rentals filename=app/templates/about.hbs
-@@ -1,5 +1,4 @@
--<div class="jumbo">
--  <div class="right tomster"></div>
-+<Jumbo>
-   <h2>About Super Rentals</h2>
-   <p>
-     The Super Rentals website is a delightful project created to explore Ember.
-@@ -7,4 +6,4 @@
-     AND building Ember applications.
-   </p>
-   <LinkTo @route="contact" class="button">Contact Us</LinkTo>
--</div>
-+</Jumbo>
+```run:file:patch lang=gjs cwd=super-rentals filename=app/templates/about.gjs
+@@ -1,6 +1,6 @@
+ import { LinkTo } from '@ember/routing'; 
++import Jumbo from 'super-rentals/components/jumbo';
+ 
+ <template>
+-  <div class="jumbo">
+-    <div class="right tomster"></div>
++  <Jumbo>
+     <h2>About Super Rentals</h2>
+@@ -12,3 +12,3 @@ import { LinkTo } from '@ember/routing';
+     <LinkTo @route="contact" class="button">Contact Us</LinkTo>
+-  </div>
++  </Jumbo>
+ </template>
 ```
 
-```run:file:patch lang=handlebars cwd=super-rentals filename=app/templates/contact.hbs
-@@ -1,5 +1,4 @@
--<div class="jumbo">
--  <div class="right tomster"></div>
-+<Jumbo>
-   <h2>Contact Us</h2>
-   <p>
-     Super Rentals Representatives would love to help you<br>
-@@ -15,4 +14,4 @@
-     <a href="mailto:superrentalsrep@emberjs.com">superrentalsrep@emberjs.com</a>
-   </address>
-   <LinkTo @route="about" class="button">About</LinkTo>
--</div>
-+</Jumbo>
+```run:file:patch lang=gjs cwd=super-rentals filename=app/templates/contact.gjs
+@@ -1,6 +1,6 @@
+ import { LinkTo } from '@ember/routing'; 
++import Jumbo from 'super-rentals/components/jumbo';
+ 
+ <template>
+-  <div class="jumbo">
+-    <div class="right tomster"></div>
++  <Jumbo>
+     <h2>Contact Us</h2>
+@@ -20,3 +20,3 @@ import { LinkTo } from '@ember/routing';
+     <LinkTo @route="about" class="button">About</LinkTo>
+-  </div>
++  </Jumbo>
+ </template>
 ```
 
 After saving, everything should look exactly the same as before, and all the tests should still pass. Very nice!
 
 ```run:command hidden=true cwd=super-rentals
 ember test --path dist
-git add app/templates/index.hbs
-git add app/templates/about.hbs
-git add app/templates/contact.hbs
+git add app/templates/index.gjs
+git add app/templates/about.gjs
+git add app/templates/contact.gjs
 ```
 
 ```run:screenshot width=1024 retina=true filename=about.png alt="About page – nothing changed"
@@ -150,12 +156,17 @@ ember generate component-test jumbo
 ```
 
 ```run:command hidden=true cwd=super-rentals
-git add tests/integration/components/jumbo-test.js
+git add tests/integration/components/jumbo-test.gjs
 ```
 
 Here, we used the generator to generate a *[component test](../../../testing/testing-components/)*, also known as a rendering test. These are used to render and test a single component at a time. This is in contrast to the acceptance tests that we wrote earlier, which have to navigate and render entire pages worth of content.
 
 Let's replace the boilerplate code that was generated for us with our own test:
+
+```run:pause
+CHECK YO SELF - tests
+```
+
 
 ```run:file:patch lang=js cwd=super-rentals filename=tests/integration/components/jumbo-test.js
 @@ -8,18 +8,8 @@

--- a/src/markdown/tutorial/part-1/04-component-basics.md
+++ b/src/markdown/tutorial/part-1/04-component-basics.md
@@ -227,7 +227,7 @@ import { LinkTo } from '@ember/routing';
       </LinkTo>
     </div>
   </nav>
-<template>
+</template>
 ```
 
 ```run:command hidden=true cwd=super-rentals
@@ -343,13 +343,15 @@ wait  #qunit-banner.qunit-pass
 
 Before we move on to the next feature, there is one more thing we could clean up. Since the `<NavBar>` is used for site-wide navigation, it really needs to be displayed on *every* page in the app. So far, we have been adding the component on each page manually. This is a bit error-prone, as we could easily forget to do this the next time that we add a new page.
 
-We can solve this problem by moving the nav-bar into a special template called `application.hbs`. You may remember that it was generated for us when we first created the app but we deleted it. Now, it's time for us to bring it back!
+We can solve this problem by moving the nav-bar into a special template called `application.gjs`. You may remember that it was generated for us when we first created the app but we deleted it. Now, it's time for us to bring it back!
 
 This template is special in that it does not have its own URL and cannot be navigated to on its own. Rather, it is used to specify a common layout that is shared by every page in your app. This is a great place to put site-wide UI elements, like a nav-bar and a site footer.
 
 While we are at it, we will also add a container element that wraps around the whole page, as requested by our designer for styling purposes.
 
 ```run:file:create lang=gjs cwd=super-rentals filename=app/templates/application.gjs
+import NavBar from 'super-rentals/components/nav-bar';
+
 <template>
   <div class="container">
     <NavBar />
@@ -360,28 +362,35 @@ While we are at it, we will also add a container element that wraps around the w
 </template>
 ```
 
-```run:pause
-CHECK YO SELF - nav 
+```run:file:patch lang=gjs cwd=super-rentals filename=app/templates/index.gjs
+@@ -2,6 +2,4 @@ import { LinkTo } from '@ember/routing';
+ import Jumbo from 'super-rentals/components/jumbo';
+-import NavBar from 'super-rentals/components/nav-bar';
+ 
+ <template>
+-  <NavBar />
+   <Jumbo>
 ```
 
 
-```run:file:patch lang=handlebars cwd=super-rentals filename=app/templates/index.hbs
-@@ -1,2 +1 @@
--<NavBar />
- <Jumbo>
+```run:file:patch lang=gjs cwd=super-rentals filename=app/templates/contact.gjs
+@@ -2,6 +2,4 @@ import { LinkTo } from '@ember/routing';
+ import Jumbo from 'super-rentals/components/jumbo';
+-import NavBar from 'super-rentals/components/nav-bar';
+ 
+ <template>
+-  <NavBar />
+   <Jumbo>
 ```
 
-
-```run:file:patch lang=handlebars cwd=super-rentals filename=app/templates/contact.hbs
-@@ -1,2 +1 @@
--<NavBar />
- <Jumbo>
-```
-
-```run:file:patch lang=handlebars cwd=super-rentals filename=app/templates/about.hbs
-@@ -1,2 +1 @@
--<NavBar />
- <Jumbo>
+```run:file:patch lang=gjs cwd=super-rentals filename=app/templates/about.gjs
+@@ -2,6 +2,4 @@ import { LinkTo } from '@ember/routing';
+ import Jumbo from 'super-rentals/components/jumbo';
+-import NavBar from 'super-rentals/components/nav-bar';
+ 
+ <template>
+-  <NavBar />
+   <Jumbo>
 ```
 
 The `{{outlet}}` keyword denotes the place where our site's pages should be rendered into, similar to the `{{yield}}` keyword we saw [earlier](#toc_passing-content-to-components-with-yield).
@@ -390,10 +399,10 @@ This is much nicer! We can run our test suite, which confirms that everything st
 
 ```run:command hidden=true cwd=super-rentals
 ember test --path dist
-git add app/templates/application.hbs
-git add app/templates/index.hbs
-git add app/templates/contact.hbs
-git add app/templates/about.hbs
+git add app/templates/application.gjs
+git add app/templates/index.gjs
+git add app/templates/contact.gjs
+git add app/templates/about.gjs
 ```
 
 ```run:screenshot width=1024 height=512 retina=true filename=pass-5.png alt="Tests still passing with {{outlet}}"

--- a/src/markdown/tutorial/part-1/05-more-about-components.md
+++ b/src/markdown/tutorial/part-1/05-more-about-components.md
@@ -172,7 +172,10 @@ Let's edit the component's template:
 Instead of hard-coding specific values for the `src` and `alt` attributes on the `<img>` tag, we opted for the `...attributes` keyword instead, which is also sometimes referred to as the *["splattributes"](../../../components/component-arguments-and-html-attributes/#toc_html-attributes)* syntax. This allows arbitrary HTML attributes to be passed in when invoking this component, like so:
 
 ```run:file:patch lang=gjs cwd=super-rentals filename=app/components/rental.gjs
-@@ -2,2 +2,6 @@
+@@ -1,3 +1,9 @@
++import RentalImage from 'super-rentals/components/rental/image';
++
+ <template>
    <article class="rental">
 +    <RentalImage
 +      src="https://upload.wikimedia.org/wikipedia/commons/c/cb/Crane_estate_(5).jpg"

--- a/src/markdown/tutorial/part-1/05-more-about-components.md
+++ b/src/markdown/tutorial/part-1/05-more-about-components.md
@@ -23,63 +23,64 @@ Let's start by creating the `<Rental>` component. This time, we will use the com
 ember generate component rental
 ```
 
-The generator created two new files for us, a component template at `app/components/rental.hbs`, and a component test file at `tests/integration/components/rental-test.js`.
+The generator created two new files for us, a component template at `app/components/rental.gjs`, and a component test file at `tests/integration/components/rental-test.gjs`.
 
 ```run:command hidden=true cwd=super-rentals
 ember test --path dist
-git add app/components/rental.hbs
-git add tests/integration/components/rental-test.js
+git add app/components/rental.gjs
+git add tests/integration/components/rental-test.gjs
 ```
 
-We will start by editing the template. Let's *[hard-code](https://en.wikipedia.org/wiki/Hard_coding)* the details for one rental property for now, and replace it with the real data from the server later on.
+We will start by editing the component template. Let's *[hard-code](https://en.wikipedia.org/wiki/Hard_coding)* the details for one rental property for now, and replace it with the real data from the server later on.
 
-```run:file:patch lang=handlebars cwd=super-rentals filename=app/components/rental.hbs
-@@ -1,1 +1,17 @@
--{{yield}}
-\ No newline at end of file
-+<article class="rental">
-+  <div class="details">
-+    <h3>Grand Old Mansion</h3>
-+    <div class="detail owner">
-+      <span>Owner:</span> Veruca Salt
+```run:file:patch lang=gjs cwd=super-rentals filename=app/components/rental.gjs
+@@ -1,3 +1,19 @@
+ <template>
+-  {{yield}}
++  <article class="rental">
++    <div class="details">
++      <h3>Grand Old Mansion</h3>
++      <div class="detail owner">
++        <span>Owner:</span> Veruca Salt
++      </div>
++      <div class="detail type">
++        <span>Type:</span> Standalone
++      </div>
++      <div class="detail location">
++        <span>Location:</span> San Francisco
++      </div>
++      <div class="detail bedrooms">
++        <span>Number of bedrooms:</span> 15
++      </div>
 +    </div>
-+    <div class="detail type">
-+      <span>Type:</span> Standalone
-+    </div>
-+    <div class="detail location">
-+      <span>Location:</span> San Francisco
-+    </div>
-+    <div class="detail bedrooms">
-+      <span>Number of bedrooms:</span> 15
-+    </div>
-+  </div>
-+</article>
++  </article>
+ </template>
 ```
 
 Then, we will write a test to ensure all of the details are present. We will replace the boilerplate test generated for us with our own assertions, just like we did for the `<Jumbo>` component earlier:
 
-```run:file:patch lang=js cwd=super-rentals filename=tests/integration/components/rental-test.js
-@@ -8,18 +8,11 @@
-
+```run:file:patch lang=gjs cwd=super-rentals filename=tests/integration/components/rental-test.gjs
+@@ -8,20 +8,11 @@ module('Integration | Component | rental', function (hooks) {
+ 
 -  test('it renders', async function (assert) {
--    // Set any properties with this.set('myProperty', 'value');
--    // Handle any actions with this.set('myAction', function(val) { ... });
+-    // Updating values is achieved using autotracking, just like in app code. For example:
+-    // class State { @tracked myProperty = 0; }; const state = new State();
+-    // and update using state.myProperty = 1; await rerender();
+-    // Handle any actions with function myAction(val) { ... };
 -
--    await render(hbs`<Rental />`);
--
++  test('it renders information about a rental property', async function (assert) {
+     await render(<template><Rental /></template>);
+ 
 -    assert.dom().hasText('');
 -
 -    // Template block usage:
--    await render(hbs`
+-    await render(<template>
 -      <Rental>
 -        template block text
 -      </Rental>
--    `);
+-    </template>);
 -
 -    assert.dom().hasText('template block text');
-+  test('it renders information about a rental property', async function (assert) {
-+    await render(hbs`<Rental />`);
-+
 +    assert.dom('article').hasClass('rental');
 +    assert.dom('article h3').hasText('Grand Old Mansion');
 +    assert.dom('article .detail.owner').includesText('Veruca Salt');
@@ -93,8 +94,8 @@ The test should pass.
 
 ```run:command hidden=true cwd=super-rentals
 ember test --path dist
-git add app/components/rental.hbs
-git add tests/integration/components/rental-test.js
+git add app/components/rental.gjs
+git add tests/integration/components/rental-test.gjs
 ```
 
 ```run:screenshot width=1024 height=512 retina=true filename=pass.png alt="Tests passing with the new <Rental> test"
@@ -104,22 +105,27 @@ wait  #qunit-banner.qunit-pass
 
 Finally, let's invoke this a couple of times from our index template to populate the page.
 
-```run:file:patch lang=handlebars cwd=super-rentals filename=app/templates/index.hbs
-@@ -5 +5,9 @@
- </Jumbo>
+```run:file:patch lang=gjs cwd=super-rentals filename=app/templates/index.gjs
+@@ -2,2 +2,3 @@ import { LinkTo } from '@ember/routing';
+ import Jumbo from 'super-rentals/components/jumbo';
++import Rental from 'super-rentals/components/rental';
+ 
+@@ -9,2 +10,10 @@ import Jumbo from 'super-rentals/components/jumbo';
+   </Jumbo>
 +
-+<div class="rentals">
-+  <ul class="results">
-+    <li><Rental /></li>
-+    <li><Rental /></li>
-+    <li><Rental /></li>
-+  </ul>
-+</div>
++  <div class="rentals">
++    <ul class="results">
++      <li><Rental /></li>
++      <li><Rental /></li>
++      <li><Rental /></li>
++    </ul>
++  </div>
+ </template>
 ```
 
 ```run:command hidden=true cwd=super-rentals
 ember test --path dist
-git add app/templates/index.hbs
+git add app/templates/index.gjs
 ```
 
 With that, we should see the `<Rental>` component showing our Grand Old Mansion three times on the page:
@@ -130,6 +136,11 @@ wait  .rentals li:nth-of-type(3) article.rental
 ```
 
 Things are looking pretty convincing already; not bad for just a little bit of work!
+
+
+```run:pause
+CHECK YO SELF - onto rental/image
+```
 
 ## Organizing Code with Namespaced Components
 

--- a/src/markdown/tutorial/part-1/05-more-about-components.md
+++ b/src/markdown/tutorial/part-1/05-more-about-components.md
@@ -137,12 +137,7 @@ wait  .rentals li:nth-of-type(3) article.rental
 
 Things are looking pretty convincing already; not bad for just a little bit of work!
 
-
-```run:pause
-CHECK YO SELF - onto rental/image
-```
-
-## Organizing Code with Namespaced Components
+## Organizing Code in Folders
 
 Next, let's add the image for the rental property. We will use the component generator for this again:
 
@@ -150,21 +145,27 @@ Next, let's add the image for the rental property. We will use the component gen
 ember generate component rental/image
 ```
 
-This time, we had a `/` in the component's name. This resulted in the component being created at `app/components/rental/image.hbs`, which can be invoked as `<Rental::Image>`.
+This time, we had a `/` in the component's name. This resulted in the component being created at `app/components/rental/image.gjs`.
 
 ```run:command hidden=true cwd=super-rentals
 ember test --path dist
-git add app/components/rental/image.hbs
-git add tests/integration/components/rental/image-test.js
+git add app/components/rental/image.gjs
+git add tests/integration/components/rental/image-test.gjs
 ```
 
-Components like these are known as *[namespaced](https://en.wikipedia.org/wiki/Namespace)* components. Namespacing allows us to organize our components by folders according to their purpose. This is completely optional&mdash;namespaced components are not special in any way.
+We can organize our components by folders according to their purpose. This is completely optional&mdash;these components are not special in any way.
 
 ## Forwarding HTML Attributes with `...attributes`
 
+
+```run:pause
+CHECK YO SELF - pre patch all the files
+```
+
+
 Let's edit the component's template:
 
-```run:file:patch lang=handlebars cwd=super-rentals filename=app/components/rental/image.hbs
+```run:file:patch lang=gjs cwd=super-rentals filename=app/components/rental/image.gjs
 @@ -1,1 +1,3 @@
 -{{yield}}
 \ No newline at end of file
@@ -175,7 +176,7 @@ Let's edit the component's template:
 
 Instead of hard-coding specific values for the `src` and `alt` attributes on the `<img>` tag, we opted for the `...attributes` keyword instead, which is also sometimes referred to as the *["splattributes"](../../../components/component-arguments-and-html-attributes/#toc_html-attributes)* syntax. This allows arbitrary HTML attributes to be passed in when invoking this component, like so:
 
-```run:file:patch lang=handlebars cwd=super-rentals filename=app/components/rental.hbs
+```run:file:patch lang=gjs cwd=super-rentals filename=app/components/rental.gjs
 @@ -1,2 +1,6 @@
  <article class="rental">
 +  <Rental::Image
@@ -187,18 +188,18 @@ Instead of hard-coding specific values for the `src` and `alt` attributes on the
 
 We specified a `src` and an `alt` HTML attribute here, which will be passed along to the component and attached to the element where `...attributes` is applied in the component template. You can think of this as being similar to `{{yield}}`, but for HTML attributes specifically, rather than displayed content. In fact, we have already used this feature [earlier](../building-pages/) when we passed a `class` attribute to `<LinkTo>`.
 
-```run:screenshot width=1024 retina=true filename=rental-image.png alt="The <Rental::Image> component in action"
+```run:screenshot width=1024 retina=true filename=rental-image.png alt="The <Image> component in action"
 visit http://localhost:4200/?deterministic
 wait  .rentals li:nth-of-type(3) article.rental .image img
 ```
 
-This way, our `<Rental::Image>` component is not coupled to any specific rental property on the site. Of course, the hard-coding problem still exists (we simply moved it to the `<Rental>` component), but we will deal with that soon. We will limit all the hard-coding to the `<Rental>` component, so that we will have an easier time cleaning it up when we switch to fetching real data.
+This way, our `<Image>` component is not coupled to any specific rental property on the site. Of course, the hard-coding problem still exists (we simply moved it to the `<Rental>` component), but we will deal with that soon. We will limit all the hard-coding to the `<Rental>` component, so that we will have an easier time cleaning it up when we switch to fetching real data.
 
 In general, it is a good idea to add `...attributes` to the primary element in your component. This will allow for maximum flexibility, as the invoker may need to pass along classes for styling or ARIA attributes to improve accessibility.
 
 Let's write a test for our new component!
 
-```run:file:patch lang=js cwd=super-rentals filename=tests/integration/components/rental/image-test.js
+```run:file:patch lang=gjs cwd=super-rentals filename=tests/integration/components/rental/image-test.gjs
 @@ -8,18 +8,15 @@
 
 -  test('it renders', async function (assert) {
@@ -235,26 +236,26 @@ Let's write a test for our new component!
 
 ## Determining the Appropriate Amount of Test Coverage
 
-Finally, we should also update the tests for the `<Rental>` component to confirm that we successfully invoked `<Rental::Image>`.
+Finally, we should also update the tests for the `<Rental>` component to confirm that we successfully invoked `<Image>`.
 
-```run:file:patch lang=js cwd=super-rentals filename=tests/integration/components/rental-test.js
+```run:file:patch lang=gjs cwd=super-rentals filename=tests/integration/components/rental-test.gjs
 @@ -17,2 +17,3 @@
      assert.dom('article .detail.bedrooms').includesText('15');
 +    assert.dom('article .image').exists();
    });
 ```
 
-Because we already tested `<Rental::Image>` extensively on its own, we can omit the details here and keep our assertion to the bare minimum. That way, we won't  *also* have to update the `<Rental>` tests whenever we make changes to `<Rental::Image>`.
+Because we already tested `<Image>` extensively on its own, we can omit the details here and keep our assertion to the bare minimum. That way, we won't  *also* have to update the `<Rental>` tests whenever we make changes to `<Image>`.
 
 ```run:command hidden=true cwd=super-rentals
 ember test --path dist
-git add app/components/rental.hbs
-git add app/components/rental/image.hbs
-git add tests/integration/components/rental-test.js
-git add tests/integration/components/rental/image-test.js
+git add app/components/rental.gjs
+git add app/components/rental/image.gjs
+git add tests/integration/components/rental-test.gjs
+git add tests/integration/components/rental/image-test.gjs
 ```
 
-```run:screenshot width=1024 height=512 retina=true filename=pass-2.png alt="Tests passing with the new <Rental::Image> test"
+```run:screenshot width=1024 height=512 retina=true filename=pass-2.png alt="Tests passing with the new <Image> test"
 visit http://localhost:4200/tests?nocontainer&nolint&deterministic
 wait  #qunit-banner.qunit-pass
 ```

--- a/src/markdown/tutorial/part-1/05-more-about-components.md
+++ b/src/markdown/tutorial/part-1/05-more-about-components.md
@@ -157,95 +157,96 @@ We can organize our components by folders according to their purpose. This is co
 
 ## Forwarding HTML Attributes with `...attributes`
 
-
-```run:pause
-CHECK YO SELF - pre patch all the files
-```
-
-
 Let's edit the component's template:
 
 ```run:file:patch lang=gjs cwd=super-rentals filename=app/components/rental/image.gjs
-@@ -1,1 +1,3 @@
--{{yield}}
-\ No newline at end of file
-+<div class="image">
-+  <img ...attributes>
-+</div>
+@@ -1,3 +1,5 @@
+ <template>
+-  {{yield}}
++  <div class="image">
++    <img ...attributes />
++  </div>
+ </template>
 ```
 
 Instead of hard-coding specific values for the `src` and `alt` attributes on the `<img>` tag, we opted for the `...attributes` keyword instead, which is also sometimes referred to as the *["splattributes"](../../../components/component-arguments-and-html-attributes/#toc_html-attributes)* syntax. This allows arbitrary HTML attributes to be passed in when invoking this component, like so:
 
 ```run:file:patch lang=gjs cwd=super-rentals filename=app/components/rental.gjs
-@@ -1,2 +1,6 @@
- <article class="rental">
-+  <Rental::Image
-+    src="https://upload.wikimedia.org/wikipedia/commons/c/cb/Crane_estate_(5).jpg"
-+    alt="A picture of Grand Old Mansion"
-+  />
-   <div class="details">
+@@ -2,2 +2,6 @@
+   <article class="rental">
++    <RentalImage
++      src="https://upload.wikimedia.org/wikipedia/commons/c/cb/Crane_estate_(5).jpg"
++      alt="A picture of Grand Old Mansion"
++    />
+     <div class="details">
 ```
 
 We specified a `src` and an `alt` HTML attribute here, which will be passed along to the component and attached to the element where `...attributes` is applied in the component template. You can think of this as being similar to `{{yield}}`, but for HTML attributes specifically, rather than displayed content. In fact, we have already used this feature [earlier](../building-pages/) when we passed a `class` attribute to `<LinkTo>`.
 
-```run:screenshot width=1024 retina=true filename=rental-image.png alt="The <Image> component in action"
+```run:screenshot width=1024 retina=true filename=rental-image.png alt="The <RentalImage> component in action"
 visit http://localhost:4200/?deterministic
 wait  .rentals li:nth-of-type(3) article.rental .image img
 ```
 
-This way, our `<Image>` component is not coupled to any specific rental property on the site. Of course, the hard-coding problem still exists (we simply moved it to the `<Rental>` component), but we will deal with that soon. We will limit all the hard-coding to the `<Rental>` component, so that we will have an easier time cleaning it up when we switch to fetching real data.
+This way, our `<RentalImage>` component is not coupled to any specific rental property on the site. Of course, the hard-coding problem still exists (we simply moved it to the `<Rental>` component), but we will deal with that soon. We will limit all the hard-coding to the `<Rental>` component, so that we will have an easier time cleaning it up when we switch to fetching real data.
 
 In general, it is a good idea to add `...attributes` to the primary element in your component. This will allow for maximum flexibility, as the invoker may need to pass along classes for styling or ARIA attributes to improve accessibility.
 
 Let's write a test for our new component!
 
 ```run:file:patch lang=gjs cwd=super-rentals filename=tests/integration/components/rental/image-test.gjs
-@@ -8,18 +8,15 @@
-
+@@ -3,3 +3,3 @@ import { setupRenderingTest } from 'super-rentals/tests/helpers';
+ import { render } from '@ember/test-helpers';
+-import Image from 'super-rentals/components/rental/image';
++import RentalImage from 'super-rentals/components/rental/image';
+ 
+@@ -8,21 +8,16 @@ module('Integration | Component | rental/image', function (hooks) {
+ 
 -  test('it renders', async function (assert) {
--    // Set any properties with this.set('myProperty', 'value');
--    // Handle any actions with this.set('myAction', function(val) { ... });
+-    // Updating values is achieved using autotracking, just like in app code. For example:
+-    // class State { @tracked myProperty = 0; }; const state = new State();
+-    // and update using state.myProperty = 1; await rerender();
+-    // Handle any actions with function myAction(val) { ... };
 -
--    await render(hbs`<Rental::Image />`);
+-    await render(<template><Image /></template>);
 -
 -    assert.dom().hasText('');
 -
 -    // Template block usage:
--    await render(hbs`
--      <Rental::Image>
--        template block text
--      </Rental::Image>
--    `);
--
--    assert.dom().hasText('template block text');
 +  test('it renders the given image', async function (assert) {
-+    await render(hbs`
-+      <Rental::Image
+     await render(<template>
+-      <Image>
+-        template block text
+-      </Image>
++      <RentalImage
 +        src="/assets/images/teaching-tomster.png"
 +        alt="Teaching Tomster"
 +      />
-+    `);
-+
+     </template>);
+ 
+-    assert.dom().hasText('template block text');
+-  });
 +    assert
 +      .dom('.image img')
 +      .exists()
 +      .hasAttribute('src', '/assets/images/teaching-tomster.png')
 +      .hasAttribute('alt', 'Teaching Tomster');
-   });
++   });
+ });
 ```
 
 ## Determining the Appropriate Amount of Test Coverage
 
-Finally, we should also update the tests for the `<Rental>` component to confirm that we successfully invoked `<Image>`.
+Finally, we should also update the tests for the `<Rental>` component to confirm that we successfully invoked `<RentalImage>`.
 
 ```run:file:patch lang=gjs cwd=super-rentals filename=tests/integration/components/rental-test.gjs
-@@ -17,2 +17,3 @@
+@@ -17,2 +17,3 @@ module('Integration | Component | rental', function (hooks) {
      assert.dom('article .detail.bedrooms').includesText('15');
 +    assert.dom('article .image').exists();
    });
 ```
 
-Because we already tested `<Image>` extensively on its own, we can omit the details here and keep our assertion to the bare minimum. That way, we won't  *also* have to update the `<Rental>` tests whenever we make changes to `<Image>`.
+Because we already tested `<RentalImage>` extensively on its own, we can omit the details here and keep our assertion to the bare minimum. That way, we won't  *also* have to update the `<Rental>` tests whenever we make changes to `<RentalImage>`.
 
 ```run:command hidden=true cwd=super-rentals
 ember test --path dist
@@ -255,7 +256,7 @@ git add tests/integration/components/rental-test.gjs
 git add tests/integration/components/rental/image-test.gjs
 ```
 
-```run:screenshot width=1024 height=512 retina=true filename=pass-2.png alt="Tests passing with the new <Image> test"
+```run:screenshot width=1024 height=512 retina=true filename=pass-2.png alt="Tests passing with the new <RentalImage> test"
 visit http://localhost:4200/tests?nocontainer&nolint&deterministic
 wait  #qunit-banner.qunit-pass
 ```

--- a/src/markdown/tutorial/part-1/06-interactive-components.md
+++ b/src/markdown/tutorial/part-1/06-interactive-components.md
@@ -32,36 +32,56 @@ Here, we are going to do just that! We are going to implement the "View Larger" 
 
 In other words, we want a way to *toggle* the image between one of the two *[states](../../../components/component-state-and-actions/)*. In order to do that, we need a way for the component to store two possible states, and to be aware of which state it is currently in.
 
-Ember optionally allows us to associate JavaScript code with a component for exactly this purpose. We can add a JavaScript file for our `<Rental::Image>` component by running the `component-class` generator:
+Ember optionally allows us to associate JavaScript code with a component for exactly this purpose. We can add JavaScript to our `<RentalImage>` component by "wrapping" the component in a class definition.
 
-```run:command cwd=super-rentals
-ember generate component-class rental/image
+```run:file:patch lang=gjs cwd=super-rentals filename=app/components/rental/image.gjs
+@@ -1,5 +1,9 @@
+-<template>
+-  <div class="image">
+-    <img ...attributes />
+-  </div>
+-</template>
++import Component from '@glimmer/component';
++
++export default class RentalImage extends Component {
++  <template>
++    <div class="image">
++      <img ...attributes />
++    </div>
++  </template>
++}
 ```
 
 ```run:command hidden=true cwd=super-rentals
 ember test --path dist
-git add app/components/rental/image.js
+git add app/components/rental/image.gjs
 ```
 
-This generated a JavaScript file with the same name as our component's template at `app/components/rental/image.js`. It contains a *[JavaScript class](https://javascript.info/class)*, *[inheriting](https://javascript.info/class-inheritance)* from `@glimmer/component`.
+Now our component contains a *[JavaScript class](https://javascript.info/class)*, *[inheriting](https://javascript.info/class-inheritance)* from `@glimmer/component`.
 
 > Zoey says...
 >
-> `@glimmer/component`, or *[Glimmer component](../../../upgrading/current-edition/glimmer-components/)*, is one of the several component classes available to use. They are a great starting point whenever you want to add behavior to your components. In this tutorial, we will be using Glimmer components exclusively.
+> Until now, all our components have been *[Template-only components][TODO: link to template-only]*. Glimmer components are used exactly like Template-only components and they are both used interchangeably in this tutorial.
 >
-> In general, Glimmer components should be used whenever possible. However, you may also see `@ember/components`, or *[classic components](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)*, used in older apps. You can tell them apart by looking at their import path (which is helpful for looking up the respective documentation, as they have different and incompatible APIs).
+> In general, whenever you want to add behavior to your components, use a JavaScript Glimmer component, otherwise use a Template-only component. 
+>
 
 Ember will create an *[instance][TODO: link to instance]* of the class whenever our component is invoked. We can use that instance to store our state:
 
-```run:file:patch lang=js cwd=super-rentals filename=app/components/rental/image.js
-@@ -3 +3,6 @@
--export default class RentalImage extends Component {}
-+export default class RentalImage extends Component {
+```run:file:patch lang=gjs cwd=super-rentals filename=app/components/rental/image.gjs
+@@ -3,2 +3,7 @@ import Component from '@glimmer/component';
+ export default class RentalImage extends Component {
 +  constructor(...args) {
 +    super(...args);
 +    this.isLarge = false;
 +  }
-+}
++
+   <template>
+```
+
+```run:command hidden=true cwd=super-rentals
+ember test --path dist
+git add app/components/rental/image.gjs
 ```
 
 Here, in the *[component's constructor][TODO: link to component's constructor]*, we *[initialized][TODO: link to initialized]* the *[instance variable][TODO: link to instance variable]* `this.isLarge` with the value `false`, since this is the default state that we want for our component.
@@ -70,36 +90,37 @@ Here, in the *[component's constructor][TODO: link to component's constructor]*,
 
 Let's update our template to use this state we just added:
 
-```run:file:patch lang=handlebars cwd=super-rentals filename=app/components/rental/image.hbs
-@@ -1,3 +1,11 @@
--<div class="image">
--  <img ...attributes>
--</div>
-+{{#if this.isLarge}}
-+  <div class="image large">
-+    <img ...attributes>
-+    <small>View Smaller</small>
-+  </div>
-+{{else}}
-+  <div class="image">
-+    <img ...attributes>
-+    <small>View Larger</small>
-+  </div>
-+{{/if}}
+```run:file:patch lang=gjs cwd=super-rentals filename=app/components/rental/image.gjs
+@@ -9,5 +9,13 @@ export default class RentalImage extends Component {
+   <template>
+-    <div class="image">
+-      <img ...attributes />
+-    </div>
++    {{#if this.isLarge}}
++      <div class="image large">
++        <img ...attributes>
++        <small>View Smaller</small>
++      </div>
++    {{else}}
++      <div class="image">
++        <img ...attributes>
++        <small>View Larger</small>
++      </div>
++    {{/if}}
+   </template>
 ```
 
-In the template, we have access to the component's instance variables. The `{{#if ...}}...{{else}}...{{/if}}` *[conditionals](../../../components/conditional-content/)* syntax allows us to render different content based on a condition (in this case, the value of the instance variable `this.isLarge`). Combining these two features, we can render either the small or the large version of the image accordingly.
+In the component's template section, we have access to the component's JavaScript instance variables. The `{{#if ...}}...{{else}}...{{/if}}` *[conditionals](../../../components/conditional-content/)* syntax allows us to render different content based on a condition (in this case, the value of the instance variable `this.isLarge`). Combining these two features, we can render either the small or the large version of the image accordingly.
 
 ```run:command hidden=true cwd=super-rentals
 ember test --path dist
-git add app/components/rental/image.hbs
-git add app/components/rental/image.js
+git add app/components/rental/image.gjs
 ```
 
 We can verify this works by temporarily changing the initial value in our JavaScript file. If we change `app/components/rental/image.js` to initialize `this.isLarge = true;` in the constructor, we should see the large version of the property image in the browser. Cool!
 
-```run:file:patch hidden=true cwd=super-rentals filename=app/components/rental/image.js
-@@ -5,3 +5,3 @@
+```run:file:patch lang=gjs hidden=true cwd=super-rentals filename=app/components/rental/image.gjs
+@@ -5,3 +5,3 @@ export default class RentalImage extends Component {
      super(...args);
 -    this.isLarge = false;
 +    this.isLarge = true;
@@ -114,30 +135,35 @@ wait  .rentals li:nth-of-type(3) article.rental .image.large img
 Once we've tested this out, we can change `this.isLarge` back to `false`.
 
 ```run:command hidden=true cwd=super-rentals
-git checkout app/components/rental/image.js
+git checkout app/components/rental/image.gjs
 ```
 
 Since this pattern of initializing instance variables in the constructor is pretty common, there happens to be a much more concise syntax for it:
 
-```run:file:patch lang=js cwd=super-rentals filename=app/components/rental/image.js
-@@ -3,6 +3,3 @@
+```run:file:patch lang=gjs cwd=super-rentals filename=app/components/rental/image.gjs
+@@ -3,6 +3,3 @@ import Component from '@glimmer/component';
  export default class RentalImage extends Component {
 -  constructor(...args) {
 -    super(...args);
 -    this.isLarge = false;
 -  }
 +  isLarge = false;
- }
+ 
 ```
 
 This does exactly the same thing as before, but it's much shorter and less to type!
 
 ```run:command hidden=true cwd=super-rentals
 ember test --path dist
-git add app/components/rental/image.js
+git add app/components/rental/image.gjs
 ```
 
 Of course, our users cannot edit our source code, so we need a way for them to toggle the image size from the browser. Specifically, we want to toggle the value of `this.isLarge` whenever the user clicks on our component.
+
+
+```run:pause
+CHECK YO SELF - TRACKED PROPS
+```
 
 ## Managing State with Tracked Properties
 

--- a/src/markdown/tutorial/part-1/06-interactive-components.md
+++ b/src/markdown/tutorial/part-1/06-interactive-components.md
@@ -57,7 +57,7 @@ ember test --path dist
 git add app/components/rental/image.gjs
 ```
 
-Now our component contains a *[JavaScript class](https://javascript.info/class)*, *[inheriting](https://javascript.info/class-inheritance)* from `@glimmer/component`.
+Now our component contains a *[JavaScript class](https://javascript.info/class)*, *[inheriting](https://javascript.info/class-inheritance)* from `@glimmer/component`. The template is now nested inside the class definition.
 
 > Zoey says...
 >
@@ -205,32 +205,36 @@ Finally, we added the `@action` decorator to our method. This indicates to Ember
 >
 > If you forget to add the `@action` decorator, you will also get a helpful error when clicking on the button in development mode!
 
-With that, it's time to wire this up in the template:
+With that, it's time to wire this up in the template section:
 
 ```run:file:patch lang=gjs cwd=super-rentals filename=app/components/rental/image.gjs
-@@ -1,11 +1,11 @@
- {{#if this.isLarge}}
--  <div class="image large">
-+  <button type="button" class="image large" {{on "click" this.toggleSize}}>
-     <img ...attributes>
-     <small>View Smaller</small>
--  </div>
-+  </button>
- {{else}}
--  <div class="image">
-+  <button type="button" class="image" {{on "click" this.toggleSize}}>
-     <img ...attributes>
-     <small>View Larger</small>
--  </div>
-+  </button>
- {{/if}}
+@@ -3,2 +3,3 @@ import { tracked } from '@glimmer/tracking';
+ import { action } from '@ember/object';
++import { on } from '@ember/modifier';
+ 
+@@ -13,11 +14,11 @@ export default class RentalImage extends Component {
+     {{#if this.isLarge}}
+-      <div class="image large">
++      <button type="button" class="image large" {{on "click" this.toggleSize}}>
+         <img ...attributes>
+         <small>View Smaller</small>
+-      </div>
++      </button>
+     {{else}}
+-      <div class="image">
++      <button type="button" class="image" {{on "click" this.toggleSize}}>
+         <img ...attributes>
+         <small>View Larger</small>
+-      </div>
++      </button>
+     {{/if}}
 ```
 
 We changed two things here.
 
 First, since we wanted to make our component interactive, we switched the containing tag from `<div>` to `<button>` (this is important for accessibility reasons). By using the correct semantic tag, we will also get focusability and keyboard interaction handling "for free".
 
-Next, we used the `{{on}}` *[modifier](../../../components/template-lifecycle-dom-and-modifiers/#toc_event-handlers)* to attach `this.toggleSize` as a click handler on the button.
+Next, we used the `{{on}}` *[modifier](../../../components/template-lifecycle-dom-and-modifiers/#toc_event-handlers)* to attach `this.toggleSize` as a click handler on the button. The `{{on}}` modifier is imported from the `@ember/modifier` package, which is part of Ember.
 
 With that, we have created our first *[interactive][TODO: link to interactive]* component. Go ahead and try it in the browser!
 
@@ -310,30 +314,24 @@ Let's clean up our template before moving on. We introduced a lot of duplication
 These changes are buried deep within the large amount of duplicated code. We can reduce the duplication by using an `{{if}}` *[expression](../../../components/conditional-content/#toc_inline-if)* instead:
 
 ```run:file:patch lang=gjs cwd=super-rentals filename=app/components/rental/image.gjs
-@@ -12,17 +12,12 @@ export default class RentalImage extends Component {
+@@ -13,13 +13,10 @@ export default class RentalImage extends Component {
    <template>
 -    {{#if this.isLarge}}
--      <div class="image large">
 -      <button type="button" class="image large" {{on "click" this.toggleSize}}>
 -        <img ...attributes>
-+    <div class="image large">
 +    <button type="button" class="image {{if this.isLarge "large"}}" {{on "click" this.toggleSize}}>
 +      <img ...attributes>
 +      {{#if this.isLarge}}
          <small>View Smaller</small>
--      </div>
 -      </button>
 -    {{else}}
--      <div class="image">
 -      <button type="button" class="image" {{on "click" this.toggleSize}}>
 -        <img ...attributes>
 +      {{else}}
          <small>View Larger</small>
--      </div>
 -      </button>
 -    {{/if}}
 +      {{/if}}
-+    </div>
 +    </button>
    </template>
 ```
@@ -356,7 +354,7 @@ Optionally, `{{if}}` can take a third argument for what the expression should ev
 -        <small>View Larger</small>
 -      {{/if}}
 +      <small>View {{if this.isLarge "Smaller" "Larger"}}</small>
-     </div>
+     </button>
 ```
 
 Whether or not this is an improvement in the clarity of our code is mostly a matter of taste. Either way, we have significantly reduced the duplication in our code, and made the important bits of logic stand out from the rest.

--- a/src/markdown/tutorial/part-1/08-working-with-data.md
+++ b/src/markdown/tutorial/part-1/08-working-with-data.md
@@ -71,12 +71,12 @@ So, now that we've prepared some model data for our route, let's use it in our t
 
 To test that this is working, let's modify our template and try to render the `title` property from our model:
 
-```run:file:patch lang=handlebars cwd=super-rentals filename=app/templates/index.hbs
-@@ -6,2 +6,4 @@
-
-+<h1>{{@model.title}}</h1>
+```run:file:patch lang=gjs cwd=super-rentals filename=app/templates/index.gjs
+@@ -11,2 +11,4 @@ import Rental from 'super-rentals/components/rental';
+ 
++  <h1>{{@model.title}}</h1>
 +
- <div class="rentals">
+   <div class="rentals">
 ```
 
 If we look at our page in the browser, we should see our model data reflected as a new header.
@@ -91,7 +91,7 @@ Awesome!
 ```run:command hidden=true cwd=super-rentals
 ember test --path dist
 git add app/routes/index.js
-git add app/templates/index.hbs
+git add app/templates/index.gjs
 ```
 
 Okay, now that we know that we have a model to use at our disposal, let's remove some of the hard-coding that we did earlier! Instead of explicitly hard-coding the rental information into our `<Rental>` component, we can pass the model object to our component instead.
@@ -100,66 +100,63 @@ Let's try it out.
 
 First, let's pass in our model to our `<Rental>` component as the `@rental` argument. We will also remove the extraneous `<h1>` tag we added earlier, now that we know things are working:
 
-```run:file:patch lang=handlebars cwd=super-rentals filename=app/templates/index.hbs
-@@ -6,9 +6,7 @@
-
--<h1>{{@model.title}}</h1>
+```run:file:patch lang=gjs cwd=super-rentals filename=app/templates/index.gjs
+@@ -11,9 +11,7 @@ import Rental from 'super-rentals/components/rental';
+ 
+-  <h1>{{@model.title}}</h1>
 -
- <div class="rentals">
-   <ul class="results">
--    <li><Rental /></li>
--    <li><Rental /></li>
--    <li><Rental /></li>
-+    <li><Rental @rental={{@model}} /></li>
-+    <li><Rental @rental={{@model}} /></li>
-+    <li><Rental @rental={{@model}} /></li>
-   </ul>
+   <div class="rentals">
+     <ul class="results">
+-      <li><Rental /></li>
+-      <li><Rental /></li>
+-      <li><Rental /></li>
++      <li><Rental @rental={{@model}} /></li>
++      <li><Rental @rental={{@model}} /></li>
++      <li><Rental @rental={{@model}} /></li>
+     </ul>
 ```
 
 By passing in `@model` into the `<Rental>` component as the `@rental` argument, we will have access to our "Grand Old Mansion" model object in the `<Rental>` component's template! Now, we can replace our hard-coded values in this component by using the values that live on our `@rental` model.
 
-```run:file:patch lang=handlebars cwd=super-rentals filename=app/components/rental.hbs
-@@ -2,18 +2,18 @@
-   <Rental::Image
--    src="https://upload.wikimedia.org/wikipedia/commons/c/cb/Crane_estate_(5).jpg"
--    alt="A picture of Grand Old Mansion"
-+    src={{@rental.image}}
-+    alt="A picture of {{@rental.title}}"
-   />
-   <div class="details">
--    <h3>Grand Old Mansion</h3>
-+    <h3>{{@rental.title}}</h3>
-     <div class="detail owner">
--      <span>Owner:</span> Veruca Salt
-+      <span>Owner:</span> {{@rental.owner}}
-     </div>
-     <div class="detail type">
--      <span>Type:</span> Standalone
-+      <span>Type:</span> {{@rental.type}}
-     </div>
-     <div class="detail location">
--      <span>Location:</span> San Francisco
-+      <span>Location:</span> {{@rental.city}}
-     </div>
-     <div class="detail bedrooms">
--      <span>Number of bedrooms:</span> 15
-+      <span>Number of bedrooms:</span> {{@rental.bedrooms}}
-     </div>
-@@ -21,8 +21,8 @@
-   <Map
--    @lat="37.7749"
--    @lng="-122.4194"
--    @zoom="9"
--    @width="150"
--    @height="150"
--    alt="A map of Grand Old Mansion"
-+    @lat={{@rental.location.lat}}
-+    @lng={{@rental.location.lng}}
-+    @zoom="9"
-+    @width="150"
-+    @height="150"
-+    alt="A map of {{@rental.title}}"
-   />
+```run:file:patch lang=gjs cwd=super-rentals filename=app/components/rental.gjs
+@@ -6,18 +6,18 @@ import Map from 'super-rentals/components/map';
+     <RentalImage
+-      src="https://upload.wikimedia.org/wikipedia/commons/c/cb/Crane_estate_(5).jpg"
+-      alt="A picture of Grand Old Mansion"
++      src={{@rental.image}}
++      alt="A picture of {{@rental.title}}"
+     />
+     <div class="details">
+-      <h3>Grand Old Mansion</h3>
++      <h3>{{@rental.title}}</h3>
+       <div class="detail owner">
+-        <span>Owner:</span> Veruca Salt
++        <span>Owner:</span> {{@rental.owner}}
+       </div>
+       <div class="detail type">
+-        <span>Type:</span> Standalone
++        <span>Type:</span> {{@rental.type}}
+       </div>
+       <div class="detail location">
+-        <span>Location:</span> San Francisco
++        <span>Location:</span> {{@rental.city}}
+       </div>
+       <div class="detail bedrooms">
+-        <span>Number of bedrooms:</span> 15
++        <span>Number of bedrooms:</span> {{@rental.bedrooms}}
+       </div>
+@@ -25,4 +25,4 @@ import Map from 'super-rentals/components/map';
+     <Map
+-      @lat="37.7749"
+-      @lng="-122.4194"
++      @lat={{@rental.location.lat}}
++      @lng={{@rental.location.lng}}
+       @zoom="9"
+@@ -30,3 +30,3 @@ import Map from 'super-rentals/components/map';
+       @height="150"
+-      alt="A map of Grand Old Mansion"
++      alt="A map of {{@rental.title}}"
+     />
 ```
 
 Since the model object contains exactly the same data as the previously-hard-coded "Grand Old Mansion", the page should look exactly the same as before the change.
@@ -173,14 +170,18 @@ Now, we have one last thing to do: update the tests to reflect this change.
 
 Because component tests are meant to render and test a single component in isolation from the rest of the app, they do not perform any routing, which means we won't have access to the same data returned from the `model` hook.
 
-Therefore, in our `<Rental>` component's test, we will have to feed the data into it some other way. We can do this using the `setProperties` we learned about from the [previous chapter](../reusable-components/).
+Therefore, in our `<Rental>` component's test, we will have to feed the data into it some other way. We can do this using the same `State` mechanism we learned about from the [previous chapter](../reusable-components/).
 
-```run:file:patch lang=js cwd=super-rentals filename=tests/integration/components/rental-test.js
-@@ -9,3 +9,22 @@
+```run:file:patch lang=gjs cwd=super-rentals filename=tests/integration/components/rental-test.gjs
+@@ -4,2 +4,3 @@ import { render } from '@ember/test-helpers';
+ import Rental from 'super-rentals/components/rental';
++import { tracked } from '@glimmer/tracking';
+ 
+@@ -9,3 +10,24 @@ module('Integration | Component | rental', function (hooks) {
    test('it renders information about a rental property', async function (assert) {
--    await render(hbs`<Rental />`);
-+    this.setProperties({
-+      rental: {
+-    await render(<template><Rental /></template>);
++    class State { 
++      @tracked rental = {
 +        title: 'Grand Old Mansion',
 +        owner: 'Veruca Salt',
 +        city: 'San Francisco',
@@ -195,20 +196,22 @@ Therefore, in our `<Rental>` component's test, we will have to feed the data int
 +          'https://upload.wikimedia.org/wikipedia/commons/c/cb/Crane_estate_(5).jpg',
 +        description:
 +          'This grand old mansion sits on over 100 acres of rolling hills and dense redwood forests.',
-+      },
-+    });
++      };
++    };
 +
-+    await render(hbs`<Rental @rental={{this.rental}} />`);
-
++    const state = new State();
++
++    await render(<template><Rental @rental={{state.rental}} /></template>);
+ 
 ```
 
 Notice that we also need to update the invocation of the `<Rental>` component in the `render` function call to also have a `@rental` argument passed into it. If we run our tests now, they should all pass!
 
 ```run:command hidden=true cwd=super-rentals
 ember test --path dist
-git add app/components/rental.hbs
-git add app/templates/index.hbs
-git add tests/integration/components/rental-test.js
+git add app/components/rental.gjs
+git add app/templates/index.gjs
+git add tests/integration/components/rental-test.gjs
 ```
 
 ```run:screenshot width=1024 height=768 retina=true filename=pass.png alt="All our tests are passing"
@@ -348,16 +351,16 @@ The last change we'll need to make is to our `index.hbs` route template, where w
 
 Let's see how.
 
-```run:file:patch lang=handlebars cwd=super-rentals filename=app/templates/index.hbs
-@@ -8,5 +8,5 @@
-   <ul class="results">
--    <li><Rental @rental={{@model}} /></li>
--    <li><Rental @rental={{@model}} /></li>
--    <li><Rental @rental={{@model}} /></li>
-+    {{#each @model as |rental|}}
-+      <li><Rental @rental={{rental}} /></li>
-+    {{/each}}
-   </ul>
+```run:file:patch lang=gjs cwd=super-rentals filename=app/templates/index.gjs
+@@ -13,5 +13,5 @@ import Rental from 'super-rentals/components/rental';
+     <ul class="results">
+-      <li><Rental @rental={{@model}} /></li>
+-      <li><Rental @rental={{@model}} /></li>
+-      <li><Rental @rental={{@model}} /></li>
++      {{#each @model as |rental|}}
++        <li><Rental @rental={{rental}} /></li>
++      {{/each}}
+     </ul>
 ```
 
 We can use the `{{#each}}...{{/each}}` syntax to iterate and loop through the array returned by the model hook. For each iteration through the array&mdash;for each item in the array&mdash;we will render the block that is passed to it once. In our case, the block is our `<Rental>` component, surrounded by `<li>` tags.
@@ -378,7 +381,7 @@ Better yet, all of our tests are still passing too!
 ```run:command hidden=true cwd=super-rentals
 ember test --path dist
 git add app/routes/index.js
-git add app/templates/index.hbs
+git add app/templates/index.gjs
 ```
 
 ```run:screenshot width=1024 height=768 retina=true filename=pass-2.png alt="All our tests are passing"


### PR DESCRIPTION
This converts Super Rentals to strict mode with `gjs`.

I finished part one so far. Here are some notes I took while converting:

### 01 orientation

The unique thing here is creating the app with `--strict`.
Basic `hbs` to `gjs` conversion.

### 02 building pages

The conversion from `hbs` to `gjs` is straightforward. However, when it's time to add `LinkTo`, it means that we have to introduce importing components. Before when we used this component, we just said of components: "you can tell them apart from regular HTML tags because they start with an uppercase letter".  Now we have to say a little more and mention components "need to be imported before they can be used".  I think I settled on good language for this point in the tutorial, but make suggestions if you feel differently.

### 03 automated testing

Basic `hbs` to `gjs` conversion.

### 04 component basics

There was a "Zoey says" callout that was a reminder about the rules of loose mode invocation (e.g., "remember to capitalize", and the filename is the component name). I removed this, but we may want to add a new callout about conventions maybe?

### 05 more about components

This is where I made some editorial decisions that we may want to discuss. Strict mode eliminates the invocation of namespaced components, so I renamed the section called "Organizing Code with Namespaced Components" to "Organizing Code with Folders".  (The term "folder" was used instead of "directory" because that is used in the accompanying prose.)  Prose discussion of the `::` syntax was removed and references to `<Rental::Image>` were updated to `<RentalImage>`. I used `RentalImage` for the imported name because later when we add a the component parts, we use `RentalImage` and that's what the generator would call it.  This creates a minor point of friction because `Image` is what the generated test uses. I also considered just removing the hierarchy altogether and making the new component `RentalImage` (file: `rental-image.gjs`). Putting files in folders is not in any way a unique Ember thing like the special syntax used with loose mode namespaced component invocations; I'm not convinced this even needs to be in this tutorial.  

### 06 interactive components

I made a handful of changes here.
In the loose mode version, this chapter updates an existing component, `Rental::Image` by adding a backing class. It does this by running the (now defunct) `component-class` generator.  It goes on to explain Glimmer components and how they should be used instead of classic components.
I updated this to add the component class to the existing by replacing the generator call with a patch block. The prose was updated from talking about "a JavaScript file with the same name as our component's template" to talking about how to update a template-only gjs file to one with a class. I feel pretty strongly this is the right way to do this, but I could use some feedback on the actual wording.

Later, the loose mode version has consecutive sections: "Adding Behavior to Components with Classes" and "Accessing Instance States from Templates".  I combined these two and updated the prose to treat the "template" and "component" as the same thing.  For example, I updated "in the template, we have access to the component's instance variables" to be "in the component's template section, we have access to the component's JavaScript instance variables". Again, if anyone has any feedback, let me know.

### 07 reusable components

I made some prose updates regarding the generator's strict mode options. I updated lines like "the component generator does not generate a JavaScript file for us by default" to "the component generator does not generate the JavaScript parts of the file for us by default".

Again, the prose says things like "Let's start with our JavaScript file:" then later, "Now, let's move from the JavaScript file to the template:", with multiple patches to the two files.  I updated it to discuss the component as a single unit and consolidated the patches (.js+.hbs) into one (.gjs) patch.

The biggest change here is explaining how state works in tests since our strict mode tests don't use the same test context. The calls to `this.setProperties` were updated to use a local `State` class and `state` instance with `@tracked` properties.  For subsequent changes to the state, `await rerender()` calls were added. The prose was updated to replace the description of `this.setProperties` and test context via `this` with an explanation of the new mechanisms. Let me know if it needs changing. 

### 08 working with data

This chapter is mostly data and routing, so there aren't many changes beyond the basic `hbs` to `gjs` conversion. I did have to update a tests to avoid `this.setProperties`.

Part two still to do (4 more chapters). 
