### PR TITLE
Replace TomTom with MapLibre and OpenFreeMap

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,12 +77,7 @@ jobs:
       - name: Compile (typescript)
         run: pnpm tsc
       - name: Generate
-        run: pnpm generate
-        env:
-          # This is needed for external PRs to build, since secrets are not
-          # available there. Get your own TomTom token for local development
-          # at: https://developer.tomtom.com
-          TOMTOM_ACCESS_TOKEN: 'gI4oJc3MF9PREfA3SIbN4ak7giIJPYcf'
+        run: pnpm generate  
       - name: Lint (markdown output)
         run: pnpm lint:md:dist
       - name: Prune artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,10 +27,10 @@ jobs:
           git config --global user.name "Tomster"
           git config --global user.email "tomster@emberjs.com"
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20'
           cache: 'pnpm'
@@ -47,7 +47,7 @@ jobs:
         # This is also suggested by Chromium https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
         run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         name: Setup cache for puppeteer
         with:
           # See .puppeteerrc.cjs, where we set this as the place puppeteer
@@ -90,26 +90,26 @@ jobs:
         working-directory: dist/code/super-rentals
         run: git clean -dfX
       - name: Upload artifacts (assets)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: assets (${{ matrix.channel }})
           path: dist/assets
       - name: Upload artifacts (markdown)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: markdown (${{ matrix.channel }})
           path: dist/markdown
       - name: Upload artifacts (code)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: code (${{ matrix.channel }})
           path: dist/code/super-rentals
           include-hidden-files: true
       - name: Notify Discord # This is a step rather than a job because of the matrix
-        uses: sarisia/actions-status-discord@v1
+        uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708 # v1.16.0
         if: ${{ failure() && github.event_name == 'schedule' }}
         with:
           webhook: ${{ secrets.CORE_META_WEBHOOK }}
@@ -166,7 +166,7 @@ jobs:
           git config --global user.name "Tomster"
           git config --global user.email "tomster@emberjs.com"
       - name: Set up SSH
-        uses: webfactory/ssh-agent@v0.4.1
+        uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         with:
           ssh-private-key: ${{ secrets.GUIDES_SOURCE_DEPLOY_KEY }}
       - name: Install dependencies
@@ -174,12 +174,12 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y zipcmp advancecomp optipng perceptualdiff
       - name: Download artifacts (assets)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: assets (release)
           path: assets
       - name: Download artifacts (markdown)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: markdown (release)
           path: markdown
@@ -272,7 +272,7 @@ jobs:
 
           git add public/images
       - name: Upload artifacts (perceptualdiff)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: perceptualdiff (release)
@@ -333,11 +333,11 @@ jobs:
           git config --global user.name "Tomster"
           git config --global user.email "tomster@emberjs.com"
       - name: Set up SSH
-        uses: webfactory/ssh-agent@v0.4.1
+        uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         with:
           ssh-private-key: ${{ secrets.SUPER_RENTALS_DEPLOY_KEY }}
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: code (release)
           path: .
@@ -392,11 +392,11 @@ jobs:
           git config --global user.name "Tomster"
           git config --global user.email "tomster@emberjs.com"
       - name: Set up SSH
-        uses: webfactory/ssh-agent@v0.4.1
+        uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         with:
           ssh-private-key: ${{ secrets.SUPER_RENTALS_DEPLOY_KEY }}
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: code (release)
           path: output

--- a/.local.dic
+++ b/.local.dic
@@ -26,7 +26,6 @@ source-readibility
 Splattributes
 swappable
 syntaxes
-TomTom
 triple-backtick
 unstyled
 untracked

--- a/.local.dic
+++ b/.local.dic
@@ -36,3 +36,10 @@ EmberData
 RequestManager
 centric
 WarpDrive
+MapLibre
+MapLibre 
+GL
+OpenFreeMap
+autotracking
+untrusted
+teardown

--- a/README.md
+++ b/README.md
@@ -593,8 +593,6 @@ Options:
 * Probably only works on Unix/bash for now (PRs welcome)
   * Should probably run the build in a docker container anyway
 * `pnpm install`
-* `TOMTOM_ACCESS_TOKEN=your-token-here pnpm build`
-  * Please note that you will need a TomTom token in order to successfully run `pnpm build`, otherwise the build will fail due to failing to load the map images. You can get your own token [here](https://developer.tomtom.com). Once you have a token, you should assign it to the `TOMTOM_ACCESS_TOKEN` environment variable.
 * Processed markdown can be found in `dist/markdown`
 * The `super-rentals` code can be found in `dist/code/super-rentals`
 

--- a/src/lib/plugins/run-code-blocks/directives/screenshot.ts
+++ b/src/lib/plugins/run-code-blocks/directives/screenshot.ts
@@ -77,7 +77,7 @@ async function main() {
       case 'click':
         if (params[1] === 'true') {
           script.push(`  await Promise.all([`);
-          script.push(`    page.waitForNavigation({ waitUtil: 'networkidle0' }),`);
+          script.push(`    page.waitForNavigation({ waitUntil: 'networkidle0' }),`);
           script.push(`    page.click(${js(params[0])})`);
           script.push(`  ]);`);
         } else {
@@ -91,7 +91,15 @@ async function main() {
         script.push(`  await page.evaluate(${js(params[0])});`);
         break;
       case 'visit':
-        script.push(`  await page.goto(${js(params[0])}, { waitUtil: 'networkidle0' });`);
+        script.push(`  for (let _attempt = 0; _attempt < 3; _attempt++) {`);
+        script.push(`    try {`);
+        script.push(`      await page.goto(${js(params[0])}, { waitUntil: 'networkidle0' });`);
+        script.push(`      break;`);
+        script.push(`    } catch (e) {`);
+        script.push(`      if (_attempt === 2) throw e;`);
+        script.push(`      await new Promise(r => setTimeout(r, 2000));`);
+        script.push(`    }`);
+        script.push(`  }`);
         break;
       case 'wait':
         script.push(`  await page.waitForSelector(${js(params[0])});`);
@@ -160,6 +168,7 @@ export default async function screenshot(node: Code, options: Options, vfile: VF
   let path = join(dir, filename) as `${string}.png`;
   let script = compile(node.value, path, args);
 
+  console.log(`\nGenerating screenshot: ${path}\n`)
   console.log(`$ node -\n${script.trimRight()}`);
 
   let p = exec(`node -`);
@@ -173,6 +182,7 @@ export default async function screenshot(node: Code, options: Options, vfile: VF
   let { alt } = args;
   let { position, data } = node;
 
+  console.log(`\nScreenshot generated: ${src}\n`);
   return {
     type: 'image',
     url: src,

--- a/src/markdown/tutorial/part-1/07-reusable-components.md
+++ b/src/markdown/tutorial/part-1/07-reusable-components.md
@@ -6,72 +6,27 @@ The last missing feature for the `<Rental>` component is a map to show the locat
 
 While adding the map, you will learn about:
 
-* Managing application-level configurations
+* Installing and using third-party packages
+* Using modifiers to interact with the DOM
 * Parameterizing components with arguments
 * Accessing component arguments
-* Interpolating values in templates
+* Safely injecting styles with `trustHTML`
 * Overriding HTML attributes in `...attributes`
 * Refactoring with getters and auto-track
 * Getting JavaScript values into the test context
 
-## Managing Application-level Configurations
-
-We will use the [TomTom](https://developer.tomtom.com/map-display-api/documentation/product-information/introduction) API to generate maps for our rental properties. You can [sign up](https://developer.tomtom.com) for free and without a credit card.
-
-TomTom provides a [static map images API](https://developer.tomtom.com/map-display-api/documentation/raster/static-image), which serves map images in PNG format. This means that we can generate the appropriate URL for the parameters we want and render the map using a standard `<img>` tag. Pretty neat!
-
-Once you have signed up, grab your *[default public token](https://developer.tomtom.com/user/me/apps)* and paste it into `config/environment.js`:
-
-```run:file:patch lang=js cwd=super-rentals filename=config/environment.js
-@@ -50,2 +50,4 @@
-
-+  ENV.TOMTOM_ACCESS_TOKEN = 'paste your TomTom API key here';
-+
-   return ENV;
-```
-
-As its name implies, `config/environment.js` is used to *configure* our app and store API keys like these. These values can be accessed from other parts of our app, and they can have different values depending on the current environment (which might be development, test, or production).
-
-```run:command hidden=true cwd=super-rentals
-pnpm test
-git add config/environment.js
-```
-
-```run:file:patch hidden=true cwd=super-rentals filename=config/environment.js
-@@ -50,3 +50,3 @@
-
--  ENV.TOMTOM_ACCESS_TOKEN = 'paste your TomTom API key here';
-+  ENV.TOMTOM_ACCESS_TOKEN = process.env.TOMTOM_ACCESS_TOKEN;
-
-```
-
-```run:command hidden=true cwd=super-rentals
-pnpm test
-git add config/environment.js
-```
-
-After saving the changes to our configuration file, we will need to restart our development server to pick up these file changes. Unlike the files we have edited so far, `config/environment.js` is not automatically reloaded.
-
-<!-- TODO: https://github.com/ember-cli/ember-cli/issues/8782 -->
-
-You can stop the server by finding the terminal window where `npm start` is running, then type `Ctrl + C`. That is, typing the "C" key on your keyboard *while* holding down the "Ctrl" key at the same time. Once it has stopped, you can start it back up again with the same `npm start` command.
-
-```run:server:start cwd=super-rentals expect="Local:   http://localhost:4200/"
-#[cfg(all(ci, unix))]
-#[display(npm start)]
-npm start | awk '{ \
-  gsub("Build successful \\([0-9]+ms\\)", "Build successful (13286ms)"); \
-  print; \
-  system("") # https://unix.stackexchange.com/a/83853 \
-}'
-
-#[cfg(not(all(ci, unix)))]
-npm start
-```
-
 ## Generating a Component with a Component Class
 
-With the TomTom API key in place, let's generate a new component for our map.
+We will use [MapLibre GL JS](https://maplibre.org/), an open-source mapping library, to render interactive maps. Since MapLibre GL is just an npm package, we can install and use it exactly as we would in any plain JavaScript project.
+
+Let's add it to our app:
+
+```run:command cwd=super-rentals
+#[display(npm install maplibre-gl --save-dev)]
+pnpm add -D maplibre-gl 
+```
+
+Now let's generate a new component for our map.
 
 ```run:command cwd=super-rentals
 ember generate component map --component-class=@glimmer/component
@@ -87,165 +42,325 @@ However, in the case of our `<Map>` component, we are pretty sure that we are go
 
 ```run:command hidden=true cwd=super-rentals
 pnpm test
+git add package.json
 git add app/components/map.gjs
 git add tests/integration/components/map-test.gjs
 ```
 
-## Parameterizing Components with Arguments
+## Making use of arguments to create a reusable Map component
 
-Let's update our component:
+Let's update our component to render an interactive map:
 
 ```run:file:patch lang=gjs cwd=super-rentals filename=app/components/map.gjs
-@@ -1,6 +1,18 @@
+@@ -1,7 +1,27 @@
  import Component from '@glimmer/component';
-+import ENV from 'super-rentals/config/environment';
++import { modifier } from 'ember-modifier';
++import maplibregl from 'maplibre-gl';
++import 'maplibre-gl/dist/maplibre-gl.css';
++
++const MAP_STYLE = 'https://tiles.openfreemap.org/styles/liberty';
++
++const displayMap = modifier((element, [lat, lng, zoom]) => {
++  const map = new maplibregl.Map({
++    container: element,
++    style: MAP_STYLE,
++    center: [lng, lat],
++    zoom,
++  });
++
++  new maplibregl.Marker().setLngLat([lng, lat]).addTo(map);
++
++  return () => map.remove();
++});
  
  export default class Map extends Component {
-+  get token() {
-+    return encodeURIComponent(ENV.TOMTOM_ACCESS_TOKEN);
-+  }
-+
    <template>
 -    {{yield}}
-+    <div class="map">
-+      <img
-+        alt="Map image at coordinates {{@lat}},{{@lng}}"
-+        ...attributes
-+        src="https://api.tomtom.com/map/1/staticimage?key={{this.token}}&zoom={{@zoom}}&center={{@lng}},{{@lat}}&width={{@width}}&height={{@height}}"
-+        width={{@width}} height={{@height}}
-+      >
-+    </div>
++    <div class="map"
++      {{displayMap @lat @lng @zoom}}
++    ></div>
    </template>
+ }
 ```
 
-Here, we import the access token from the config file and return it from a `token` *[getter](https://javascript.info/property-accessors)*. This allows us to access our token as `this.token` both inside the `Map` class body, as well as the template section. It is also important to [URL-encode](https://javascript.info/url#encoding-strings) the token, just in case it contains any special characters that are not URL-safe.
+There is a lot going on here! Let's work through it piece by piece.
 
-First, we have a container element for styling purposes.
+First, we have imports for `modifier` from `ember-modifier`, `maplibregl` from `maplibre-gl`, and the MapLibre CSS file. The CSS provides the map controls and visual elements that MapLibre renders — without it, the map buttons and overlays won't look right.
 
-Then we have an `<img>` tag to request and render the static map image from TomTom.
+Next, we define a `MAP_STYLE` constant pointing to [OpenFreeMap](https://openfreemap.org/), an open-source tile server that provides free map tiles with no API key required.
 
-Our component's template contains several values that don't yet exist&mdash;`@lat`, `@lng`, `@zoom`, `@width`, and `@height`. These are *[arguments](../../../components/component-arguments-and-html-attributes/#toc_arguments)* to the `<Map>` component that we will supply when invoking it.
+The heart of this component is `displayMap`, a custom *[modifier](../../../components/template-lifecycle-dom-and-modifiers/)* created with the `modifier()` function from `ember-modifier`. A modifier is a way to run JavaScript code that directly interacts with a specific DOM element. When Ember renders `<div {{displayMap ...}}>`, our modifier function is called with two arguments: the DOM element itself, and an array of any positional arguments passed in the template. Here we use destructuring — `[lat, lng, zoom]` — to unpack that array directly in the function signature.
 
-By *[parameterizing][TODO: link to parameterizing]* our component using arguments, we made a reusable component that can be invoked from different parts of the app and customized to meet the needs for those specific contexts. We have already seen this in action when using the `<LinkTo>` component [earlier](../building-pages/); we had to specify a `@route` argument so that it knew what page to navigate to.
+Inside the modifier, we use `maplibregl` exactly as we would in plain JavaScript: instantiate a `new maplibregl.Map()`, pass it the container element, the OpenFreeMap style URL, and the coordinates, then add a `Marker` at the same position to visually pin the location. No Ember-specific APIs are needed — it is just regular JavaScript library usage.
 
-We supplied a reasonable default value for the `alt` attribute based on the values of the `@lat` and `@lng` arguments. You may notice that we are directly *[interpolating][TODO: link to interpolating]* values into the `alt` attribute's value. Ember will automatically concatenate these interpolated values into a final string value for us, including doing any necessary HTML-escaping.
+Finally, the modifier returns a *cleanup function*, `() => map.remove()`. Ember automatically calls this function when the element is removed from the DOM — for instance, when the user navigates to a different page. Returning a cleanup function is how modifiers signal to Ember what teardown work needs to happen.
 
-## Overriding HTML Attributes in `...attributes`
+Our component's template accepts `@lat`, `@lng`, and `@zoom` as *[arguments](../../../components/component-arguments-and-html-attributes/#toc_arguments)* to the `<Map>` component that we pass through to the modifier. By *[parameterizing][TODO: link to parameterizing]* our component using arguments, we made a reusable component that can be invoked from different parts of the app and customized to meet the needs for those specific contexts. We have already seen this in action when using the `<LinkTo>` component [earlier](../building-pages/); we had to specify a `@route` argument so that it knew what page to navigate to.
 
-Next, we used `...attributes` to allow the invoker to further customize the `<img>` tag, such as passing extra attributes such as `class`, as well as *[overriding][TODO: link to overriding]* our default `alt` attribute with a more specific or human-friendly one.
-
-*The ordering is important here!* Ember applies the attributes in the order that they appear. By assigning the default `alt` attribute first (*before* `...attributes` is applied), we are explicitly providing the invoker the *option* to provide a more tailored `alt` attribute according to their use case.
-
-Since the passed-in `alt` attribute (if any exists) will appear *after* ours, it will override the value we specified. On the other hand, it is important that we assign `src`, `width`, and `height` after `...attributes`, so that they don't get accidentally overwritten by the invoker.
-
-The `src` attribute interpolates all the required parameters into the URL format for TomTom's [static map image API](https://developer.tomtom.com/map-display-api/documentation/raster/static-image), including the URL-escaped access token from `this.token`.
-
-Finally, since we are using the `@2x` "retina" image, we should specify the `width` and `height` attributes. Otherwise, the `<img>` will be rendered at twice the size than what we expected!
-
-We just added a lot of behavior into a single component, so let's write some tests! In particular, we should make sure to have some *[test coverage](../../../testing/)* for the overriding-HTML-attributes behavior we discussed above.
+Let's write some initial tests to make sure the component renders correctly:
 
 ```run:file:patch lang=gjs cwd=super-rentals filename=tests/integration/components/map-test.gjs
-@@ -2,3 +2,4 @@ import { module, test } from 'qunit';
- import { setupRenderingTest } from 'super-rentals/tests/helpers';
--import { render } from '@ember/test-helpers';
-+import { render, find } from '@ember/test-helpers';
-+import ENV from 'super-rentals/config/environment';
- import Map from 'super-rentals/components/map';
-@@ -8,20 +9,79 @@ module('Integration | Component | map', function (hooks) {
- 
+@@ -8,21 +8,15 @@ module('Integration | Component | map', function (hooks) {
+
 -  test('it renders', async function (assert) {
 -    // Updating values is achieved using autotracking, just like in app code. For example:
 -    // class State { @tracked myProperty = 0; }; const state = new State();
 -    // and update using state.myProperty = 1; await rerender();
 -    // Handle any actions with function myAction(val) { ... };
-+  test('it renders a map image for the specified parameters', async function (assert) {
-+    await render(<template>
-+      <Map
-+        @lat="37.7797"
-+        @lng="-122.4184"
-+        @zoom="10"
-+        @width="150"
-+        @height="120"
-+      />
-+    </template>);
-+
-+    assert
-+      .dom('.map img')
-+      .exists()
-+      .hasAttribute('alt', 'Map image at coordinates 37.7797,-122.4184')
-+      .hasAttribute('src')
-+      .hasAttribute('width', '150')
-+      .hasAttribute('height', '120');
-+
-+    let { src } = find('.map img');
-+    let token = encodeURIComponent(ENV.TOMTOM_ACCESS_TOKEN);
-+
-+    assert.ok(
-+      src.startsWith('https://api.tomtom.com/'),
-+      'the src starts with "https://api.tomtom.com/"',
-+    );
-+
-+    assert.ok(
-+      src.includes('zoom=10'),
-+      'the src should include the zoom parameter',
-+    );
- 
+-
 -    await render(<template><Map /></template>);
-+    assert.ok(
-+      src.includes('center=-122.4184,37.7797'),
-+      'the src should include the lng,lat parameter',
-+    );
- 
+-
 -    assert.dom().hasText('');
-+    assert.ok(
-+      src.includes(`key=${token}`),
-+      'the src should include the escaped access token',
-+    );
-+  });
-+
-+  test('the default alt attribute can be overridden', async function (assert) {
-+    await render(<template>
-+      <Map
-+        @lat="37.7797"
-+        @lng="-122.4184"
-+        @zoom="10"
-+        @width="150"
-+        @height="120"
-+        alt="A map of San Francisco"
-+      />
-+    </template>);
-+
-+    assert.dom('.map img').hasAttribute('alt', 'A map of San Francisco');
-+  });
- 
+-
 -    // Template block usage:
-+  test('the src, width and height attributes cannot be overridden', async function (assert) {
-     await render(<template>
+-    await render(<template>
 -      <Map>
 -        template block text
 -      </Map>
+-    </template>);
+-
+-    assert.dom().hasText('template block text');
+-  });
++  test('it renders a map for the specified parameters', async function (assert) {
++    await render(<template>
 +      <Map
 +        @lat="37.7797"
 +        @lng="-122.4184"
 +        @zoom="10"
 +        @width="150"
 +        @height="120"
-+        src="/assets/images/teaching-tomster.png"
-+        width="200"
-+        height="300"
 +      />
-     </template>);
++    </template>);
++
++    assert.dom('.map').exists();
++  });
+ });
+```
+
+```run:command hidden=true cwd=super-rentals
+pnpm test
+git add app/components/map.gjs
+git add tests/integration/components/map-test.gjs
+```
+
+```run:server:start cwd=super-rentals expect="Local:   http://localhost:4200/"
+#[cfg(all(ci, unix))]
+#[display(npm start)]
+npm start | awk '{ \
+  gsub("Build successful \\([0-9]+ms\\)", "Build successful (13286ms)"); \
+  print; \
+  system("") # https://unix.stackexchange.com/a/83853 \
+}'
+
+#[cfg(not(all(ci, unix)))]
+npm start
+```
+
+```run:screenshot width=1024 height=768 retina=true filename=pass.png alt="Tests passing with the initial <Map> tests"
+visit http://localhost:4200/tests?nocontainer&nolint&deterministic
+wait  #qunit-banner.qunit-pass
+```
+
+## Sizing the Map with inline styles
+
+Our map renders, but it does not have a defined size yet. We want the caller to be able to pass `@width` and `@height` arguments to control the map's dimensions.
+
+The natural way to set a size is through an inline `style` attribute. You might try:
+
+```gjs
+<div class="map"
+  {{displayMap @lat @lng @zoom}}
+  style="width: {{@width}}px; height: {{@height}}px;"
+></div>
+```
+
+However, Ember will log a console warning when you do this:
+
+> Binding style attributes may introduce cross-site scripting vulnerabilities...
+
+Ember warns about dynamic string interpolation inside `style` attributes because of the risk of *[XSS (Cross-Site Scripting)](https://owasp.org/www-community/attacks/xss/)* attacks. If `@width` could ever receive a value from **untrusted** user input, a malicious string could inject arbitrary styles — or worse, `</style><script>` — into the page.
+
+To safely set a computed style string that we control, we use `trustHTML` from `@ember/template`. This function takes a string and marks it as *trusted HTML*, which tells Ember it can be used in HTML attribute contexts without further escaping:
+
+```run:file:patch lang=gjs cwd=super-rentals filename=app/components/map.gjs
+@@ -1,4 +1,5 @@
+ import Component from '@glimmer/component';
+ import { modifier } from 'ember-modifier';
++import { trustHTML } from '@ember/template';
+ import maplibregl from 'maplibre-gl';
+ import 'maplibre-gl/dist/maplibre-gl.css';
+@@ -21,5 +22,10 @@
+ export default class Map extends Component {
++  get mapSize() {
++    return trustHTML(`width: ${this.args.width}px; height: ${this.args.height}px;`);
++  }
++
+   <template>
+     <div class="map"
+       {{displayMap @lat @lng @zoom}}
++      style={{this.mapSize}}
+     ></div>
+```
+
+We add a `mapSize` *[getter](https://javascript.info/property-accessors)* to the `Map` class. From within our JavaScript class, we have access to component arguments using the `this.args.*` API. Here, `this.args.width` and `this.args.height` give us the values the caller passed as `@width` and `@height`. We interpolate those into a CSS style string and wrap the result with `trustHTML`.
+
+> Zoey says...
+>
+> `this.args` is an API provided by the Glimmer component superclass. You may come across other component superclasses, such as "classic" components in legacy codebases, that provide different APIs for accessing component arguments from JavaScript code.
+
+We chose a getter merely to demonstrate both getters and `this.args`, we could instead have used a local helper function and passed in the values for `@width` and `@height` from the template.
+
+We know using `trustHTML` here is safe because `@width` and `@height` are numbers that we control — they are component arguments passed by the caller, not raw user input read from a form field or a URL parameter.
+
+In the template, `{{this.mapSize}}` evaluates the getter and binds the resulting safe string to the `style` attribute.
+
+Let's update our test to assert that the style is applied correctly:
+
+```run:file:patch lang=gjs cwd=super-rentals filename=tests/integration/components/map-test.gjs
+@@ -19,3 +19,6 @@ module('Integration | Component | map', function (hooks) {
  
--    assert.dom().hasText('template block text');
+-    assert.dom('.map').exists();
 +    assert
-+      .dom('.map img')
-+      .hasAttribute('src', /^https:\/\/api\.tomtom\.com\//)
-+      .hasAttribute('width', '150')
-+      .hasAttribute('height', '120');
++      .dom('.map')
++      .exists()
++      .hasAttribute('style', 'width: 150px; height: 120px;');
    });
 ```
 
-Note that the `hasAttribute` test helper from [`qunit-dom`](https://github.com/simplabs/qunit-dom/blob/master/API.md) supports using *[regular expressions](https://javascript.info/regexp-introduction)*. We used this feature to confirm that the `src` attribute starts with `https://api.tomtom.com/`, as opposed to requiring it to be an exact match against a string. This allows us to be reasonably confident that the code is working correctly, without being overly-detailed in our tests.
+```run:command hidden=true cwd=super-rentals
+pnpm test
+git add app/components/map.gjs
+git add tests/integration/components/map-test.gjs
+```
+
+```run:screenshot width=1024 height=768 retina=true filename=pass-2.png alt="Tests passing after adding mapSize"
+visit http://localhost:4200/tests?nocontainer&nolint&deterministic
+wait  #qunit-banner.qunit-pass
+```
+
+## Getting JavaScript Values into the Test Context
+
+The `mapSize` helper depends on `@width` and `@height` — but does the `style` attribute update when those arguments change? Let's write a test to find out.
+
+To update component arguments from inside a test, we need a way to hold mutable state outside the template. We can create a simple class for this, using the `@tracked` decorator just like we would in application code:
+
+```run:file:patch lang=gjs cwd=super-rentals filename=tests/integration/components/map-test.gjs
+@@ -2,9 +2,10 @@ import { module, test } from 'qunit';
+ import { setupRenderingTest } from 'super-rentals/tests/helpers';
+-import { render } from '@ember/test-helpers';
++import { render, rerender } from '@ember/test-helpers';
+ import Map from 'super-rentals/components/map';
++import { tracked } from '@glimmer/tracking';
+ 
+-module('Integration | Component | map', function (hooks) {
++module('Integration | Component | map', function(hooks) {
+   setupRenderingTest(hooks);
+ 
+-  test('it renders a map for the specified parameters', async function (assert) {
++  test('it renders a map for the specified parameters', async function(assert) {
+     await render(<template>
+@@ -24,2 +25,34 @@ module('Integration | Component | map', function (hooks) {
+   });
++
++  test('it updates the style when the dimensions change', async function(assert) {
++    class State {
++      @tracked width = 150;
++      @tracked height = 120;
++    }
++
++    const state = new State();
++
++    await render(<template>
++      <Map
++        @lat="37.7797"
++        @lng="-122.4184"
++        @zoom="10"
++        @width={{state.width}}
++        @height={{state.height}}
++      />
++    </template>);
++
++    assert
++      .dom('.map')
++      .hasAttribute('style', 'width: 150px; height: 120px;');
++
++    state.width = 300;
++    state.height = 200;
++
++    await rerender();
++
++    assert
++      .dom('.map')
++      .hasAttribute('style', 'width: 300px; height: 200px;');
++  });
+ });
+```
+
+In this test we create a local `State` class and an instance called `state`. There is nothing special about the name — it's a plain JavaScript class that holds reactive data. We decorate its properties with `@tracked` so that Ember knows to re-render whenever they change.
+
+After mutating `state.width` and `state.height`, we call `await rerender()` to give Ember a chance to flush the update before we assert again.
+
+Note that we did not mark our `mapSize` getter as `@tracked`. Unlike instance variables, getters cannot be "assigned" a new value directly, so it does not make sense for Ember to monitor them for changes.
+
+That being said, the values *produced* by getters can certainly change. In our case, the value produced by `mapSize` depends on `this.args.width` and `this.args.height`. Whenever these dependencies are updated, we would expect `{{this.mapSize}}` in the template to be updated accordingly.
+
+Ember does this by automatically tracking any variables that were accessed while computing a getter's value. As long as the dependencies themselves are marked as `@tracked`, Ember knows exactly when to invalidate and re-render any templates that may contain "stale" getter values. This feature is also known as *[autotracking](../../../in-depth-topics/autotracking-in-depth/)*. 
+
+All arguments accessible from `this.args` (in other words, `this.args.*`) are implicitly marked as `@tracked` by the Glimmer component superclass. Since we inherited from that superclass, everything Just Works&trade;.
+
+Auto-track works the same way inside modifiers: if the positional arguments passed to `{{displayMap @lat @lng @zoom}}` change, Ember will call the modifier's cleanup function and re-run the modifier with the new values.
+
+```run:command hidden=true cwd=super-rentals
+pnpm test
+git add tests/integration/components/map-test.gjs
+```
+
+```run:screenshot width=1024 height=768 retina=true filename=pass-3.png alt="Tests passing after the autotracking test"
+visit http://localhost:4200/tests?nocontainer&nolint&deterministic
+wait  #qunit-banner.qunit-pass
+```
+
+## Overriding HTML Attributes in `...attributes`
+
+Next, we use `...attributes` to allow the invoker to further customize the map `<div>`, for example by passing accessibility attributes like `role` and `aria-label`:
+
+```run:file:patch lang=gjs cwd=super-rentals filename=app/components/map.gjs
+@@ -30,2 +30,3 @@ export default class Map extends Component {
+       style={{this.mapSize}}
++      ...attributes
+     ></div>
+```
+
+*The ordering is important here!* Ember applies attributes in the order they appear. By placing `...attributes` *after* `style={{this.mapSize}}`, we allow the invoker to override the inline styles if they want. Note that `...attributes` *does* forward any modifiers the caller passes — but our own `{{displayMap ...}}` is defined directly on the element, so it always runs regardless of what the caller provides.
+
+Let's add a test to verify that `...attributes` works correctly:
+
+```run:file:patch lang=gjs cwd=super-rentals filename=tests/integration/components/map-test.gjs
+@@ -57,2 +57,23 @@ module('Integration | Component | map', function(hooks) {
+   });
++
++  test('the attributes can be customized', async function(assert) {
++    await render(<template>
++      <Map
++        @lat="37.7797"
++        @lng="-122.4184"
++        @zoom="10"
++        @width="150"
++        @height="120"
++        role="img"
++        aria-label="A map of San Francisco"
++        class="my-map"
++      />
++    </template>);
++
++    assert
++      .dom('.map')
++      .hasAttribute('role', 'img')
++      .hasAttribute('aria-label', 'A map of San Francisco')
++      .hasClass('my-map');
++  });
+ });
+```
 
 *Fingers crossed...* Let's run our tests.
 
@@ -255,7 +370,7 @@ git add app/components/map.gjs
 git add tests/integration/components/map-test.gjs
 ```
 
-```run:screenshot width=1024 height=768 retina=true filename=pass.png alt="Tests passing with the new <Map> tests"
+```run:screenshot width=1024 height=768 retina=true filename=pass-4.png alt="All our tests are passing"
 visit http://localhost:4200/tests?nocontainer&nolint&deterministic
 wait  #qunit-banner.qunit-pass
 ```
@@ -267,7 +382,7 @@ Hey, all the tests passed! But does that mean it actually works in practice? Let
  import RentalImage from 'super-rentals/components/rental/image';
 +import Map from 'super-rentals/components/map';
  
-@@ -23,2 +24,10 @@ import RentalImage from 'super-rentals/components/rental/image';
+@@ -23,2 +24,11 @@ import RentalImage from 'super-rentals/components/rental/image';
      </div>
 +    <Map
 +      @lat="37.7749"
@@ -275,7 +390,8 @@ Hey, all the tests passed! But does that mean it actually works in practice? Let
 +      @zoom="9"
 +      @width="150"
 +      @height="150"
-+      alt="A map of Grand Old Mansion"
++      role="img"
++      aria-label="A map of Grand Old Mansion"
 +    />
    </article>
 ```
@@ -286,12 +402,6 @@ Hey! That's a map!
 visit http://localhost:4200/?deterministic
 wait  .rentals li:nth-of-type(3) article.rental .map
 ```
-
-<!-- TODO: https://github.com/ember-cli/ember-cli/issues/8782 -->
-
-> Zoey says...
->
-> If the map image failed to load, make sure you have the correct `TOMTOM_ACCESS_TOKEN` set in `config/environment.js`. Don't forget to restart the development and test servers after editing your config file!
 
 For good measure, we will also add an assertion to the `<Rental>` tests to make sure we rendered the `<Map>` component successfully.
 
@@ -308,172 +418,6 @@ git add app/components/rental.gjs
 git add tests/integration/components/rental-test.gjs
 ```
 
-## Refactoring with Getters and Auto-track
-
-At this point, a big part of our `<Map>` component's template section is devoted to the `<img>` tag's `src` attribute, which is getting pretty long. One alternative is to move this computation into the JavaScript class instead.
-
-From within our JavaScript class, we have access to our component's arguments using the `this.args.*` API. Using that, we can move the URL logic up from the template into a new getter.
-
-> Zoey says...
->
-> `this.args` is an API provided by the Glimmer component superclass. You may come across other component superclasses, such as "classic" components in legacy codebases, that provide different APIs for accessing component arguments from JavaScript code.
-
-```run:file:patch lang=js cwd=super-rentals filename=app/components/map.gjs
-@@ -3,3 +3,15 @@ import ENV from 'super-rentals/config/environment';
- 
-+const TOMTOM_API = 'https://api.tomtom.com/map/1/staticimage';
-+
- export default class Map extends Component {
-+  get src() {
-+    let { lng, lat, width, height, zoom } = this.args;
-+
-+    let coordinates = `&zoom=${zoom}&center=${lng},${lat}`;
-+    let dimensions = `&width=${width}&height=${height}`;
-+    let accessToken = `?key=${this.token}`;
-+
-+    return `${TOMTOM_API}${accessToken}${coordinates}${dimensions}`;
-+  }
-+
-   get token() {
-@@ -13,3 +25,3 @@ export default class Map extends Component {
-         ...attributes
--        src="https://api.tomtom.com/map/1/staticimage?key={{this.token}}&zoom={{@zoom}}&center={{@lng}},{{@lat}}&width={{@width}}&height={{@height}}"
-+        src={{this.src}}
-         width={{@width}} height={{@height}}
-```
-
-Much nicer! And all of our tests still pass!
-
-```run:command hidden=true cwd=super-rentals
-pnpm test
-git add app/components/map.gjs
-```
-
-```run:screenshot width=1024 height=768 retina=true filename=pass-2.png alt="Tests passing after the src getter refactor"
-visit http://localhost:4200/tests?nocontainer&nolint&deterministic
-wait  #qunit-banner.qunit-pass
-```
-
-Note that we did not mark our getter as `@tracked`. Unlike instance variables, getters cannot be "assigned" a new value directly, so it does not make sense for Ember to monitor them for changes.
-
-That being said, the values *produced* by getters can certainly change. In our case, the value produced by our `src` getter depends on the values of `lat`, `lng`, `width`, `height` and `zoom` from `this.args`. Whenever these *[dependencies][TODO: link to dependencies]* get updated, we would expect `{{this.src}}` from our template to be updated accordingly.
-
-Ember does this by automatically tracking any variables that were accessed while computing a getter's value. As long as the dependencies themselves are marked as `@tracked`, Ember knows exactly when to invalidate and re-render any templates that may potentially contain any "stale" and outdated getter values. This feature is also known as *[auto-track](../../../in-depth-topics/autotracking-in-depth/)*. All arguments that can be accessed from `this.args` (in other words, `this.args.*`) are implicitly marked as `@tracked` by the Glimmer component superclass. Since we inherited from that superclass, everything Just Works&trade;.
-
-## Getting JavaScript Values into the Test Context
-
-Just to be sure, we can add a test for this behavior:
-
-```run:file:patch lang=gjs cwd=super-rentals filename=tests/integration/components/map-test.gjs
-@@ -2,5 +2,6 @@ import { module, test } from 'qunit';
- import { setupRenderingTest } from 'super-rentals/tests/helpers';
--import { render, find } from '@ember/test-helpers';
-+import { render, find, rerender } from '@ember/test-helpers';
- import ENV from 'super-rentals/config/environment';
- import Map from 'super-rentals/components/map';
-+import { tracked } from '@glimmer/tracking';
- 
-@@ -52,2 +53,82 @@ module('Integration | Component | map', function (hooks) {
- 
-+  test('it updates the `src` attribute when the arguments change', async function (assert) {
-+    class State { 
-+      @tracked lat = 37.7749;
-+      @tracked lng = -122.4194;
-+      @tracked zoom = 10;
-+      @tracked width = 150;
-+      @tracked height = 120;
-+    };
-+
-+    const state = new State();
-+
-+    await render(<template>
-+      <Map
-+        @lat={{state.lat}}
-+        @lng={{state.lng}}
-+        @zoom={{state.zoom}}
-+        @width={{state.width}}
-+        @height={{state.height}}
-+      />
-+    </template>);
-+
-+    let img = find('.map img');
-+
-+    assert.ok(
-+      img.src.includes('zoom=10'),
-+      'the src should include the zoom parameter',
-+    );
-+
-+    assert.ok(
-+      img.src.includes('-122.4194,37.7749'),
-+      'the src should include the lng,lat parameter',
-+    );
-+
-+    assert.ok(
-+      img.src.includes('width=150'),
-+      'the src should include the width parameter',
-+    );
-+
-+    assert.ok(
-+      img.src.includes('height=120'),
-+      'the src should include the height parameter',
-+    );
-+
-+    state.width = 300;
-+    state.height = 200;
-+    state.zoom = 12;
-+
-+    await rerender();
-+
-+    assert.ok(
-+      img.src.includes('-122.4194,37.7749'),
-+      'the src should still include the lng,lat parameter',
-+    );
-+
-+    assert.ok(
-+      img.src.includes('width=300'),
-+      'the src should include the updated width parameter',
-+    );
-+
-+    assert.ok(
-+      img.src.includes('height=200'),
-+      'the src should include the updated height parameter',
-+    );
-+
-+    assert.ok(
-+      img.src.includes('zoom=12'),
-+      'the src should include the updated zoom parameter',
-+    );
-+
-+    state.lat = 47.6062;
-+    state.lng = -122.3321;
-+
-+    await rerender();
-+
-+    assert.ok(
-+      img.src.includes('center=-122.3321,47.6062'),
-+      'the src should include the updated lng,lat parameter',
-+    );
-+  });
-+
-   test('the default alt attribute can be overridden', async function (assert) {
-```
-
-In this test, we create a local class called `State` and an instance of that class called `state`. There is nothing special about the name `State`&mdash;it's just a regular JavaScript class we use to keep track of data we might want to pass into our component. We use the `@tracked` decorator just like in the application code so whenever we make a change, Ember will update the page automatically.
-
-In tests like this, whenever we make changes to state that is rendered, we call `await rerender()`. This gives Ember a chance to update the display before continuing with the queries and assertions that follow. Following this pattern allows us to update these values as needed from the test function.
-
-With all our tests passing, we are ready to move on!
-
-```run:command hidden=true cwd=super-rentals
-pnpm test
-git add tests/integration/components/map-test.gjs
-```
-
-```run:screenshot width=1024 height=768 retina=true filename=pass-3.png alt="All our tests are passing"
-visit http://localhost:4200/tests?nocontainer&nolint&deterministic
-wait  #qunit-banner.qunit-pass
-```
-
 ```run:server:stop
 npm start
 ```
@@ -481,4 +425,3 @@ npm start
 ```run:checkpoint cwd=super-rentals
 Chapter 7
 ```
-

--- a/src/markdown/tutorial/part-1/07-reusable-components.md
+++ b/src/markdown/tutorial/part-1/07-reusable-components.md
@@ -14,6 +14,7 @@ While adding the map, you will learn about:
 * Overriding HTML attributes in `...attributes`
 * Refactoring with getters and auto-track
 * Getting JavaScript values into the test context
+* Centralizing configuration in `config/environment`
 
 ## Generating a Component with a Component Class
 
@@ -420,6 +421,62 @@ For good measure, we will also add an assertion to the `<Rental>` tests to make 
 pnpm test
 git add app/components/rental.gjs
 git add tests/integration/components/rental-test.gjs
+```
+
+## Pulling the Tile Style URL from Configuration
+
+The `MAP_STYLE` constant is currently hardcoded inside the map component. This works, but a tile server URL is the kind of app-level setting that could reasonably differ between environments — for example, pointing at a self-hosted tile server in production while using OpenFreeMap during development. Ember's convention is to centralize these values in `config/environment.js`, where all environment-specific configuration lives.
+
+Let's move the tile style URL there:
+
+```run:file:patch lang=js cwd=super-rentals filename=config/environment.js
+@@ -40,5 +40,7 @@
+   if (environment === 'production') {
+     // here you can enable a production-specific feature
+   }
+ 
++  ENV.MAP_TILE_STYLE = 'https://tiles.openfreemap.org/styles/liberty';
++
+   return ENV;
+```
+
+Now update `map.gjs` to import `ENV` from `super-rentals/config/environment` and read the URL from there instead of the local constant:
+
+```run:file:patch lang=gjs cwd=super-rentals filename=app/components/map.gjs
+@@ -1,9 +1,8 @@
+ import Component from '@glimmer/component';
+ import { modifier } from 'ember-modifier';
+ import { trustHTML } from '@ember/template';
+ import maplibregl from 'maplibre-gl';
+ import 'maplibre-gl/dist/maplibre-gl.css';
++import ENV from 'super-rentals/config/environment';
+ 
+-const MAP_STYLE = 'https://tiles.openfreemap.org/styles/liberty';
+-
+ const displayMap = modifier((element, [lat, lng, zoom]) => {
+@@ -11,3 +10,3 @@
+     container: element,
+-    style: MAP_STYLE,
++    style: ENV.MAP_TILE_STYLE,
+     center: [lng, lat],
+```
+
+The import path `super-rentals/config/environment` is the standard Ember module 
+path that resolves to the project's `config/environment.js` file. The `ENV` 
+object it exports contains all the values we set there, for the current environment, 
+including our newly added `MAP_TILE_STYLE`. 
+The component is no longer responsible for knowing what the URL for tiles is — 
+it just reads it from the central configuration at startup.
+
+```run:command hidden=true cwd=super-rentals
+pnpm test
+git add config/environment.js
+git add app/components/map.gjs
+```
+
+```run:screenshot width=1024 height=768 retina=true filename=pass-5.png alt="All tests still passing after the refactor"
+visit http://localhost:4200/tests?nocontainer&nolint&deterministic
+wait  #qunit-banner.qunit-pass
 ```
 
 ```run:server:stop

--- a/src/markdown/tutorial/part-1/07-reusable-components.md
+++ b/src/markdown/tutorial/part-1/07-reusable-components.md
@@ -23,7 +23,11 @@ Let's add it to our app:
 
 ```run:command cwd=super-rentals
 #[display(npm install maplibre-gl --save-dev)]
-pnpm add -D maplibre-gl 
+#[cfg(unix)]
+pnpm add -D maplibre-gl 2>&1 | grep -Fv "| Progress:" | grep -Ev "WARN.*deprecated subdependencies found" | grep -Ev "^[[:space:]]*$" | grep -Fv "+26 +++" | grep -Fv "using pnpm"
+
+#[cfg(not(unix))]
+pnpm add -D maplibre-gl
 ```
 
 Now let's generate a new component for our map.

--- a/src/markdown/tutorial/part-1/08-working-with-data.md
+++ b/src/markdown/tutorial/part-1/08-working-with-data.md
@@ -152,10 +152,10 @@ By passing in `@model` into the `<Rental>` component as the `@rental` argument, 
 +      @lat={{@rental.location.lat}}
 +      @lng={{@rental.location.lng}}
        @zoom="9"
-@@ -30,3 +30,3 @@ import Map from 'super-rentals/components/map';
-       @height="150"
--      alt="A map of Grand Old Mansion"
-+      alt="A map of {{@rental.title}}"
+@@ -31,3 +31,3 @@ import Map from 'super-rentals/components/map';
+       role="img"
+-      aria-label="A map of Grand Old Mansion"
++      aria-label="A map of {{@rental.title}}"
      />
 ```
 


### PR DESCRIPTION
This PR replaces TomTom with [MapLibre GL JS](https://maplibre.org/maplibre-gl-js/docs/), an open-source mapping library. It makes use of https://openfreemap.org/ for tiles. **Both are completely free and do not require registration nor an API key.**

TomTom has been frequently causing the tutorial runs to error. It appeared to just be flaky but yesterday it began returning `{"detailedError":{"code":"InsufficientFunds","message":"You do not have enough credits to perform this action"}}` instead of the map images regularly. 

Nearly all static map image APIs appear to be paid or require a credit card. An interactive map seems the best choice. 

The example of setting an API key has been replaced with an example of keeping the URL for tile style in configuration. This does not require any registration with a third party to learn.

This PR includes https://github.com/ember-learn/super-rentals-tutorial/pull/282 and https://github.com/ember-learn/super-rentals-tutorial/pull/281. Those PRs are where I started trying to improve the flakiness of the tutorial.