### PR TITLE
Fix build: maplibre-gl 6 has no default export

### DIFF
--- a/src/markdown/tutorial/part-1/07-reusable-components.md
+++ b/src/markdown/tutorial/part-1/07-reusable-components.md
@@ -60,7 +60,7 @@ Let's update our component to render an interactive map:
 @@ -1,7 +1,27 @@
  import Component from '@glimmer/component';
 +import { modifier } from 'ember-modifier';
-+import maplibregl from 'maplibre-gl';
++import * as maplibregl from 'maplibre-gl';
 +import 'maplibre-gl/dist/maplibre-gl.css';
 +
 +const MAP_STYLE = 'https://tiles.openfreemap.org/styles/liberty';
@@ -90,7 +90,7 @@ Let's update our component to render an interactive map:
 
 There is a lot going on here! Let's work through it piece by piece.
 
-First, we have imports for `modifier` from `ember-modifier`, `maplibregl` from `maplibre-gl`, and the MapLibre CSS file. The CSS provides the map controls and visual elements that MapLibre renders — without it, the map buttons and overlays won't look right.
+First, we have imports for `modifier` from `ember-modifier`, `maplibregl` from `maplibre-gl`, and the MapLibre CSS file. The `import * as maplibregl` syntax collects everything the library exports into a single `maplibregl` object, which is how MapLibre's own documentation recommends importing it. The CSS provides the map controls and visual elements that MapLibre renders — without it, the map buttons and overlays won't look right.
 
 Next, we define a `MAP_STYLE` constant pointing to [OpenFreeMap](https://openfreemap.org/), an open-source tile server that provides free map tiles with no API key required.
 
@@ -192,7 +192,7 @@ To safely set a computed style string that we control, we use `trustHTML` from `
  import Component from '@glimmer/component';
  import { modifier } from 'ember-modifier';
 +import { trustHTML } from '@ember/template';
- import maplibregl from 'maplibre-gl';
+ import * as maplibregl from 'maplibre-gl';
  import 'maplibre-gl/dist/maplibre-gl.css';
 @@ -21,5 +22,10 @@
  export default class Map extends Component {
@@ -447,7 +447,7 @@ Now update `map.gjs` to import `ENV` from `super-rentals/config/environment` and
  import Component from '@glimmer/component';
  import { modifier } from 'ember-modifier';
  import { trustHTML } from '@ember/template';
- import maplibregl from 'maplibre-gl';
+ import * as maplibregl from 'maplibre-gl';
  import 'maplibre-gl/dist/maplibre-gl.css';
 +import ENV from 'super-rentals/config/environment';
  


### PR DESCRIPTION
The nightly build has been red on **all three channels** (release, beta, alpha) since the [2026-07-22 run](https://github.com/ember-learn/super-rentals-tutorial/actions/runs/29888628494) — the last green one was 2026-07-21.

## Cause

`maplibre-gl@6.0.0` was published in that window. It ships a pure-ESM build (`dist/maplibre-gl.mjs`, `"type": "module"`) that exports **only named bindings** — the default export that v5 provided is gone. Chapter 7 does `import maplibregl from 'maplibre-gl'`, so the app build fails:

```
[MISSING_EXPORT] "default" is not exported by ".../maplibre-gl@6.0.0/dist/maplibre-gl.mjs".
   ╭─[ app/components/map.gjs:3:8 ]
   │
 3 │ import maplibregl from 'maplibre-gl';
   │        ─────┬────
   │             ╰────── Missing export
───╯
```

([release](https://github.com/ember-learn/super-rentals-tutorial/actions/runs/30142330214) fails at the same line, as do beta and alpha.)

## Fix

Use a namespace import in the three places chapter 7 shows the import line:

```diff
-import maplibregl from 'maplibre-gl';
+import * as maplibregl from 'maplibre-gl';
```

This is what [MapLibre's own README](https://github.com/maplibre/maplibre-gl-js#readme) now recommends, and it keeps working on maplibre-gl 5, so the tutorial isn't pinned to a single major. Everything downstream in the chapter is untouched — `new maplibregl.Map(...)` and `new maplibregl.Marker()` read exactly the same, so the prose still holds. I added one sentence explaining the `* as` form, since the tutorial walks through each import.

## Verification

The full generator run needs a couple of things my machine doesn't have (`tree`, and the dev-server readiness handshake didn't settle locally), so I verified against the published output app, [ember-learn/super-rentals](https://github.com/ember-learn/super-rentals), which is the exact code this chapter generates:

1. Installed `maplibre-gl@6.0.0` into it and ran `pnpm test` → reproduced the identical `MISSING_EXPORT` build failure.
2. Applied only the import change above → `pnpm test` passes **25/25**, including the four `Integration | Component | map` tests.
3. Loaded the app in a browser to confirm this isn't just a build-time fix: the map canvases mount at their configured size and the marker renders, so the chapter screenshots should still be produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)